### PR TITLE
Feature: improving events management

### DIFF
--- a/locale/en_UK/LC_MESSAGES/django.po
+++ b/locale/en_UK/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-02-20 01:05+0000\n"
+"POT-Creation-Date: 2017-07-19 18:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,7 +25,7 @@ msgstr ""
 msgid "SPF-users"
 msgstr ""
 
-#: spbm/apps/accounts/models.py:12 templates/invoices/index.jinja:144
+#: spbm/apps/accounts/models.py:12 templates/events/view.jinja:34 templates/invoices/index.jinja:142
 msgid "Society"
 msgstr ""
 
@@ -37,12 +37,12 @@ msgstr ""
 msgid "SPF-member connected to {society}"
 msgstr ""
 
-#: spbm/apps/norlonn/models.py:13
-msgid "norlÃ¸nn report"
+#: spbm/apps/norlonn/models.py:14
+msgid "norlønn report"
 msgstr ""
 
-#: spbm/apps/norlonn/models.py:14
-msgid "norlÃ¸nn reports"
+#: spbm/apps/norlonn/models.py:15
+msgid "norlønn reports"
 msgstr ""
 
 #: spbm/apps/norlonn/views.py:26
@@ -78,156 +78,188 @@ msgstr ""
 msgid "SPBM"
 msgstr ""
 
-#: spbm/apps/society/models.py:20 spbm/apps/society/models.py:47 spbm/apps/society/models.py:92 spbm/apps/society/models.py:142
+#: spbm/apps/society/models.py:21 spbm/apps/society/models.py:52 spbm/apps/society/models.py:100 spbm/apps/society/models.py:154
 msgid "society"
 msgstr ""
 
-#: spbm/apps/society/models.py:21
+#: spbm/apps/society/models.py:22
 msgid "societies"
 msgstr ""
 
-#: spbm/apps/society/models.py:24 spbm/apps/society/models.py:54 spbm/apps/society/models.py:145
+#: spbm/apps/society/models.py:25 spbm/apps/society/models.py:59 spbm/apps/society/models.py:157
 msgid "name"
 msgstr ""
 
-#: spbm/apps/society/models.py:26
+#: spbm/apps/society/models.py:27
 msgid "abbreviated name"
 msgstr ""
 
-#: spbm/apps/society/models.py:28
+#: spbm/apps/society/models.py:29
 msgid "invoice e-mail"
 msgstr ""
 
-#: spbm/apps/society/models.py:30
+#: spbm/apps/society/models.py:31
 msgid "default wage per hour"
 msgstr ""
 
-#: spbm/apps/society/models.py:31
+#: spbm/apps/society/models.py:32
 msgid "logo"
 msgstr ""
 
-#: spbm/apps/society/models.py:43 spbm/apps/society/models.py:202
+#: spbm/apps/society/models.py:44 spbm/apps/society/models.py:233
 msgid "worker"
 msgstr ""
 
-#: spbm/apps/society/models.py:44
+#: spbm/apps/society/models.py:45
 msgid "workers"
 msgstr ""
 
-#: spbm/apps/society/models.py:51
+#: spbm/apps/society/models.py:56
 msgid "active"
 msgstr ""
 
-#: spbm/apps/society/models.py:52
+#: spbm/apps/society/models.py:57
 msgid "Check off if the worker is still actively working."
 msgstr ""
 
-#: spbm/apps/society/models.py:55
+#: spbm/apps/society/models.py:60
 msgid "Full name, with first name first."
 msgstr ""
 
-#: spbm/apps/society/models.py:57
+#: spbm/apps/society/models.py:62
 msgid "address"
 msgstr ""
 
-#: spbm/apps/society/models.py:58
+#: spbm/apps/society/models.py:63
 msgid "Full address including postal code and area."
 msgstr ""
 
-#: spbm/apps/society/models.py:61
+#: spbm/apps/society/models.py:66
 msgid "account no."
 msgstr ""
 
-#: spbm/apps/society/models.py:62
+#: spbm/apps/society/models.py:67
 msgid "Norwegian bank account number, no periods, 11 digits."
 msgstr ""
 
-#: spbm/apps/society/models.py:65
+#: spbm/apps/society/models.py:70
 msgid "person ID"
 msgstr ""
 
-#: spbm/apps/society/models.py:69
+#: spbm/apps/society/models.py:74
 msgid "norl&oslash;nn number"
 msgstr ""
 
-#: spbm/apps/society/models.py:70
+#: spbm/apps/society/models.py:75
 msgid "Employee number in the wage system, Norl&oslash;nn. <strong>Must</strong> exist and be correct!"
 msgstr ""
 
-#: spbm/apps/society/models.py:84 spbm/apps/society/models.py:161
+#: spbm/apps/society/models.py:91 spbm/apps/society/models.py:180
 msgid "invoice"
 msgstr ""
 
-#: spbm/apps/society/models.py:85
+#: spbm/apps/society/models.py:92
 msgid "invoices"
 msgstr ""
 
-#: spbm/apps/society/models.py:94
+#: spbm/apps/society/models.py:102
 msgid "invoice number"
 msgstr ""
 
-#: spbm/apps/society/models.py:96
+#: spbm/apps/society/models.py:104
 msgid "period"
 msgstr ""
 
-#: spbm/apps/society/models.py:98
+#: spbm/apps/society/models.py:106
 msgid "invoice paid"
 msgstr ""
 
-#: spbm/apps/society/models.py:100
+#: spbm/apps/society/models.py:108
 msgid "User which closed the period the invoice belongs to."
 msgstr ""
 
-#: spbm/apps/society/models.py:139
+#: spbm/apps/society/models.py:147
 msgid "event"
 msgstr ""
 
-#: spbm/apps/society/models.py:140
+#: spbm/apps/society/models.py:148
 msgid "events"
 msgstr ""
 
-#: spbm/apps/society/models.py:146
+#: spbm/apps/society/models.py:158
+msgid "Name or title describing the event."
+msgstr ""
+
+#: spbm/apps/society/models.py:159
 msgid "event date"
 msgstr ""
 
-#: spbm/apps/society/models.py:149
+#: spbm/apps/society/models.py:160
+msgid "The date of the event in the format of <em>YYYY-MM-DD</em>."
+msgstr ""
+
+#: spbm/apps/society/models.py:163
 msgid "registered"
 msgstr ""
 
-#: spbm/apps/society/models.py:152
+#: spbm/apps/society/models.py:164
+msgid "Date of event registration."
+msgstr ""
+
+#: spbm/apps/society/models.py:171
 msgid "processed"
 msgstr ""
 
-#: spbm/apps/society/models.py:180 templates/invoices/view.jinja:38
+#: spbm/apps/society/models.py:193 templates/events/index.jinja:28 templates/events/view.jinja:36
+msgid "Total hours"
+msgstr ""
+
+#: spbm/apps/society/models.py:204 templates/events/index.jinja:29 templates/events/view.jinja:37 templates/invoices/view.jinja:37
 msgid "Total cost"
 msgstr ""
 
-#: spbm/apps/society/models.py:194
+#: spbm/apps/society/models.py:225
 msgid "shift"
 msgstr ""
 
-#: spbm/apps/society/models.py:195
+#: spbm/apps/society/models.py:226
 msgid "shifts"
 msgstr ""
 
-#: spbm/apps/society/models.py:205
+#: spbm/apps/society/models.py:236
 msgid "wage"
 msgstr ""
 
-#: spbm/apps/society/models.py:208
+#: spbm/apps/society/models.py:240
 msgid "hours"
 msgstr ""
 
-#: spbm/apps/society/models.py:214
+#: spbm/apps/society/models.py:247
 msgid "norl&oslash;nn report"
 msgstr ""
 
-#: spbm/apps/society/forms/worker.py:14 templates/workers/index.jinja:25 templates/workers/index.jinja:48
+#: spbm/apps/society/models.py:254
+msgid "Worker on shift does not belong to the same society as the event."
+msgstr ""
+
+#: spbm/apps/society/models.py:256
+msgid "You must select a worker for this shift."
+msgstr ""
+
+#: spbm/apps/society/forms/worker.py:14 templates/workers/index.jinja:22 templates/workers/index.jinja:45
 msgid "National ID"
 msgstr ""
 
 #: spbm/apps/society/forms/worker.py:15
 msgid "National social security ID, 11 digits."
+msgstr ""
+
+#: spbm/apps/society/views/events.py:54
+msgid "You are not allowed to create events due to lacking permissions."
+msgstr ""
+
+#: spbm/apps/society/views/events.py:81
+msgid "You are not allowed to edit events due to lacking permissions."
 msgstr ""
 
 #: spbm/apps/society/views/invoicing.py:55
@@ -259,63 +291,63 @@ msgstr ""
 msgid "SPF fee: {percent}% of {event_cost}"
 msgstr ""
 
-#: templates/base.jinja:22
+#: templates/base.jinja:27
 msgid "Toggle navigation"
 msgstr ""
 
-#: templates/base.jinja:33
+#: templates/base.jinja:38
 msgid "Your Society"
 msgstr ""
 
-#: templates/base.jinja:38
+#: templates/base.jinja:43
 msgid "Bookings"
 msgstr ""
 
-#: templates/base.jinja:40
+#: templates/base.jinja:45
 msgid "Workers and registrations"
 msgstr ""
 
-#: templates/base.jinja:41 templates/workers/index.jinja:4
+#: templates/base.jinja:46 templates/events/index.jinja:30 templates/workers/index.jinja:2
 msgid "Workers"
 msgstr ""
 
-#: templates/base.jinja:43
+#: templates/base.jinja:48
 msgid "Events and registrations"
 msgstr ""
 
-#: templates/base.jinja:44 templates/events/index.jinja:4
+#: templates/base.jinja:49 templates/events/index.jinja:2
 msgid "Events"
 msgstr ""
 
-#: templates/base.jinja:49
+#: templates/base.jinja:54
 msgid "Invoicing"
 msgstr ""
 
-#: templates/base.jinja:54
+#: templates/base.jinja:59
 msgid "Wages"
 msgstr ""
 
-#: templates/base.jinja:62
+#: templates/base.jinja:67
 msgid "Administration"
 msgstr ""
 
-#: templates/base.jinja:67
+#: templates/base.jinja:72
 msgid "Log out of SPFs SPBM"
 msgstr ""
 
-#: templates/base.jinja:68
+#: templates/base.jinja:73
 msgid "Logout"
 msgstr ""
 
-#: templates/index.jinja:4
+#: templates/index.jinja:2
 msgid "Society overview"
 msgstr ""
 
-#: templates/index.jinja:8
+#: templates/index.jinja:5
 msgid "You're logged into an account associated with:"
 msgstr ""
 
-#: templates/index.jinja:9
+#: templates/index.jinja:6
 msgid "As of right now, this page exactly doesn't really do anything, so take a look at the navigation bar!."
 msgstr ""
 
@@ -361,246 +393,338 @@ msgstr ""
 msgid "403 Permission Denied"
 msgstr ""
 
-#: templates/events/add.jinja:4
+#: templates/events/add.jinja:2
 msgid "Add event"
 msgstr ""
 
-#: templates/events/add.jinja:30
+#: templates/events/add.jinja:7
 msgid "Create event"
 msgstr ""
 
-#: templates/events/add.jinja:32 templates/events/add.jinja:33
+#: templates/events/add.jinja:9 templates/events/add.jinja:10
 msgid "Cancel creating this event"
 msgstr ""
 
-#: templates/events/index.jinja:8
+#: templates/events/delete.jinja:2
+msgid "Confirm deletion of event"
+msgstr ""
+
+#: templates/events/delete.jinja:10
+msgid "Confirm deletion"
+msgstr ""
+
+#: templates/events/delete.jinja:14
+#, python-format
+msgid "Are you sure that you wish to delete the event %(event)s?"
+msgstr ""
+
+#: templates/events/delete.jinja:17
+msgid "Cancel deleting and take me back"
+msgstr ""
+
+#: templates/events/delete.jinja:19
+msgid "Delete the event"
+msgstr ""
+
+#: templates/events/edit.jinja:2 templates/events/index.jinja:60 templates/events/view.jinja:19
+msgid "Edit event"
+msgstr ""
+
+#: templates/events/edit.jinja:7
+msgid "Update event with changes"
+msgstr ""
+
+#: templates/events/edit.jinja:9 templates/events/edit.jinja:10
+msgid "Cancel changes"
+msgstr ""
+
+#: templates/events/form.jinja:8 templates/events/view.jinja:30
+msgid "Event details"
+msgstr ""
+
+#: templates/events/form.jinja:13
+msgid "Shift workers"
+msgstr ""
+
+#: templates/events/index.jinja:9
 msgid "Add new event"
 msgstr ""
 
-#: templates/events/index.jinja:13
+#: templates/events/index.jinja:18
 msgid "Not processed yet"
 msgstr ""
 
-#: templates/events/index.jinja:15
+#: templates/events/index.jinja:20
 #, python-format
 msgid "Processed on %(date)s"
 msgstr ""
 
-#: templates/events/index.jinja:24
-msgid "Event"
-msgstr ""
-
-#: templates/events/index.jinja:25 templates/workers/index.jinja:22 templates/workers/index.jinja:45
-msgid "Name"
-msgstr ""
-
-#: templates/events/index.jinja:26
-msgid "Hourly"
+#: templates/events/index.jinja:26 templates/events/view.jinja:35 templates/invoices/index.jinja:104
+msgid "Date"
 msgstr ""
 
 #: templates/events/index.jinja:27
-msgid "Hours"
+msgid "Event"
 msgstr ""
 
-#: templates/events/index.jinja:28 templates/invoices/view.jinja:53
-msgid "Sum"
+#: templates/events/index.jinja:39 templates/events/utils.jinja:16 templates/events/view.jinja:36
+#, python-format
+msgid "%(hours)sh"
 msgstr ""
 
-#: templates/events/index.jinja:37 templates/events/index.jinja:42 templates/invoices/index.jinja:110 templates/invoices/index.jinja:169 templates/invoices/view.jinja:48
-#: templates/invoices/view.jinja:54
+#: templates/events/index.jinja:40 templates/events/utils.jinja:15 templates/events/utils.jinja:17 templates/events/view.jinja:37 templates/invoices/index.jinja:108 templates/invoices/index.jinja:167
+#: templates/invoices/view.jinja:47 templates/invoices/view.jinja:53
 #, python-format
 msgid "NOK %(cost)s"
 msgstr ""
 
-#: templates/events/index.jinja:42
-msgid "Total"
+#: templates/events/index.jinja:51
+msgid "View the details of the event"
 msgstr ""
 
-#: templates/invoices/index.jinja:3
+#: templates/events/index.jinja:53 templates/events/view.jinja:2
+msgid "View event"
+msgstr ""
+
+#: templates/events/index.jinja:57
+msgid "Edit the event, such as date, workers, and more"
+msgstr ""
+
+#: templates/events/utils.jinja:5 templates/events/view.jinja:33 templates/workers/index.jinja:19 templates/workers/index.jinja:42
+msgid "Name"
+msgstr ""
+
+#: templates/events/utils.jinja:6
+msgid "Hourly"
+msgstr ""
+
+#: templates/events/utils.jinja:7
+msgid "Hours"
+msgstr ""
+
+#: templates/events/utils.jinja:8 templates/invoices/view.jinja:52
+msgid "Sum"
+msgstr ""
+
+#: templates/events/utils.jinja:9
+msgid "Payrolled"
+msgstr ""
+
+#: templates/events/utils.jinja:25 templates/events/utils.jinja:27
+msgid "Not payrolled"
+msgstr ""
+
+#. small title for viewing an event
+#: templates/events/view.jinja:4
+#, python-format
+msgid "Viewing %(name)s (#%(id)i)"
+msgstr ""
+
+#: templates/events/view.jinja:22
+msgid "Delete event"
+msgstr ""
+
+#: templates/events/view.jinja:42
+msgid "Invoicing and wage details"
+msgstr ""
+
+#: templates/events/view.jinja:45
+#, python-format
+msgid "This event has yet to be invoiced to a society. Please see <a href=\"%(invoices)s\" class=\"alert-link\">the invoice section</a> to close the current invoice period."
+msgstr ""
+
+#: templates/events/view.jinja:53
+#, python-format
+msgid ""
+"This event has been invoiced to %(society)s, and the wages will be paid to workers as soon as a <a class=\"alert-link\" href=\"%(payroll)s\">payroll report has been created</a> for all valid "
+"workers."
+msgstr ""
+
+#: templates/events/view.jinja:63
+msgid "Shift details"
+msgstr ""
+
+#: templates/invoices/index.jinja:2
 msgid "Invoice Management"
 msgstr ""
 
-#: templates/invoices/index.jinja:23
+#: templates/invoices/index.jinja:21
 #, python-format
 msgid "%(days)s days"
 msgstr ""
 
-#: templates/invoices/index.jinja:31
+#: templates/invoices/index.jinja:29
 msgid "Period status"
 msgstr ""
 
-#: templates/invoices/index.jinja:33
+#: templates/invoices/index.jinja:31
 #, python-format
 msgid "%(num)d unprocessed event"
 msgid_plural "%(num)d unprocessed events"
 msgstr[0] ""
 msgstr[1] ""
 
-#: templates/invoices/index.jinja:44
+#: templates/invoices/index.jinja:42
 msgid "There are unprocessed events, which means you can close the period, if it is the right time of month."
 msgstr ""
 
-#: templates/invoices/index.jinja:51
+#: templates/invoices/index.jinja:49
 msgid "Close period"
 msgstr ""
 
-#: templates/invoices/index.jinja:52 templates/norlonn/index.jinja:42
+#: templates/invoices/index.jinja:50 templates/norlonn/index.jinja:41
 msgid "Not easily reversible!"
 msgstr ""
 
-#: templates/invoices/index.jinja:56
+#: templates/invoices/index.jinja:54
 msgid "Remember to only close the invoice period <strong>max once a month, on the 15th</strong>."
 msgstr ""
 
-#: templates/invoices/index.jinja:65 templates/invoices/index.jinja:122
+#: templates/invoices/index.jinja:63 templates/invoices/index.jinja:120
 msgid "So far, so good!"
 msgstr ""
 
-#: templates/invoices/index.jinja:67
+#: templates/invoices/index.jinja:65
 msgid "There are no unprocessed events currently registered. You can register some events if you wish, <em>or</em> wait until next month."
 msgstr ""
 
-#: templates/invoices/index.jinja:79
+#: templates/invoices/index.jinja:77
 msgid "Unpaid invoices"
 msgstr ""
 
-#: templates/invoices/index.jinja:88
+#: templates/invoices/index.jinja:86
 msgid "The following invoices have yet to be paid, and will affect the next payroll thusly."
 msgstr ""
 
-#: templates/invoices/index.jinja:101
+#: templates/invoices/index.jinja:99
 msgid "Mark as paid"
 msgstr ""
 
-#: templates/invoices/index.jinja:106
-msgid "Date"
-msgstr ""
-
-#: templates/invoices/index.jinja:109
+#: templates/invoices/index.jinja:107
 msgid "Amount"
 msgstr ""
 
-#: templates/invoices/index.jinja:119
+#: templates/invoices/index.jinja:117
 msgid "There aren't any unpaid invoices! That's great!"
 msgstr ""
 
-#: templates/invoices/index.jinja:130
+#: templates/invoices/index.jinja:128
 msgid "Complete invoice overview"
 msgstr ""
 
-#: templates/invoices/index.jinja:135
+#: templates/invoices/index.jinja:133
 msgid "Overview over all the various invoices that <em>should have</em> been sent to the respective societies."
 msgstr ""
 
-#: templates/invoices/index.jinja:143
+#: templates/invoices/index.jinja:141
 msgid "Period"
 msgstr ""
 
-#: templates/invoices/index.jinja:145
+#: templates/invoices/index.jinja:143
 msgid "Invoice sum"
 msgstr ""
 
-#: templates/invoices/index.jinja:146
+#: templates/invoices/index.jinja:144
 msgid "Paid?"
 msgstr ""
 
-#: templates/invoices/index.jinja:147
+#: templates/invoices/index.jinja:145
 msgid "Actions"
 msgstr ""
 
-#: templates/invoices/index.jinja:172 templates/workers/index.jinja:35
+#: templates/invoices/index.jinja:170 templates/workers/index.jinja:32
 msgid "Yes"
 msgstr ""
 
-#: templates/invoices/index.jinja:174 templates/workers/index.jinja:35
+#: templates/invoices/index.jinja:172 templates/workers/index.jinja:32
 msgid "No"
 msgstr ""
 
-#: templates/invoices/index.jinja:180
+#: templates/invoices/index.jinja:178
 msgid "View the details of the invoice"
 msgstr ""
 
-#: templates/invoices/index.jinja:182
+#: templates/invoices/index.jinja:180
 msgid "View invoice"
 msgstr ""
 
-#: templates/invoices/index.jinja:185
+#: templates/invoices/index.jinja:183
 msgid "View PDF"
 msgstr ""
 
-#: templates/invoices/index.jinja:187
+#: templates/invoices/index.jinja:185
 msgid "View invoice PDF"
 msgstr ""
 
-#: templates/invoices/view.jinja:4
+#: templates/invoices/view.jinja:2
 #, python-format
 msgid "Invoice #%(id)s: %(date)s %(society)s"
 msgstr ""
 
-#: templates/invoices/view.jinja:13
+#: templates/invoices/view.jinja:12
 #, python-format
 msgid "Invoiced at %(period)s"
 msgstr ""
 
-#: templates/invoices/view.jinja:17
+#: templates/invoices/view.jinja:16
 #, python-format
 msgid "%(society)s"
 msgstr ""
 
-#: templates/invoices/view.jinja:26
+#: templates/invoices/view.jinja:25
 #, python-format
 msgid "Period closed by %(user)s"
 msgstr ""
 
-#: templates/invoices/view.jinja:31
+#: templates/invoices/view.jinja:30
 #, python-format
 msgid "Overview over events and costs associated with invoice number %(id)d."
 msgstr ""
 
-#: templates/invoices/view.jinja:35
+#: templates/invoices/view.jinja:34
 msgid "Description"
 msgstr ""
 
-#: templates/invoices/view.jinja:36
+#: templates/invoices/view.jinja:35
 msgid "Count"
 msgstr ""
 
-#: templates/invoices/view.jinja:37
+#: templates/invoices/view.jinja:36
 msgid "Unit cost"
 msgstr ""
 
-#: templates/invoices/view.jinja:60
+#: templates/invoices/view.jinja:59
 msgid "Return to invoice overview"
 msgstr ""
 
 #. Title for reports page.
-#: templates/norlonn/index.jinja:5
+#: templates/norlonn/index.jinja:4
 msgid "Wage Reports"
 msgstr ""
 
-#: templates/norlonn/index.jinja:10
+#: templates/norlonn/index.jinja:9
 msgid "Access to wage reports for importing into the <em>Norlønn</em> payroll system."
 msgstr ""
 
-#: templates/norlonn/index.jinja:17
+#: templates/norlonn/index.jinja:16
 msgid "Current report errors"
 msgstr ""
 
-#: templates/norlonn/index.jinja:19
+#: templates/norlonn/index.jinja:18
 msgid ""
 "There are some errors present. Please fix the errors before you attempt generating a report, as to avoid workers missing out on their wages. If the errors are associated with a different society "
 "than yours, get in touch with them over the mailing list."
 msgstr ""
 
-#: templates/norlonn/index.jinja:41
+#: templates/norlonn/index.jinja:40
 msgid "Generate new wage report"
 msgstr ""
 
-#: templates/norlonn/index.jinja:48
+#: templates/norlonn/index.jinja:47
 msgid "Existing reports"
 msgstr ""
 
-#: templates/norlonn/index.jinja:51
+#: templates/norlonn/index.jinja:50
 msgid ""
 "The following is the list of the payment reports that have been created in the past. They detail the amount of money and payments for each worker, and should only <strong>be imported once</strong> "
 "into Norlønn."
@@ -618,42 +742,42 @@ msgstr ""
 msgid "Successful elements"
 msgstr ""
 
-#: templates/workers/edit.jinja:3
+#: templates/workers/edit.jinja:2
 msgid "Edit worker"
 msgstr ""
 
-#: templates/workers/edit.jinja:17
+#: templates/workers/edit.jinja:16
 msgid "Save changes"
 msgstr ""
 
-#: templates/workers/edit.jinja:19
+#: templates/workers/edit.jinja:18
 msgid "Cancel editing this worker"
 msgstr ""
 
-#: templates/workers/edit.jinja:20
+#: templates/workers/edit.jinja:19
 msgid "Cancel editing & changes"
 msgstr ""
 
-#: templates/workers/index.jinja:8
+#: templates/workers/index.jinja:5
 msgid "Add new worker"
 msgstr ""
 
-#: templates/workers/index.jinja:14
+#: templates/workers/index.jinja:11
 msgid "Add worker"
 msgstr ""
 
-#: templates/workers/index.jinja:18
+#: templates/workers/index.jinja:15
 msgid "List of workers"
 msgstr ""
 
-#: templates/workers/index.jinja:23 templates/workers/index.jinja:46
+#: templates/workers/index.jinja:20 templates/workers/index.jinja:43
 msgid "Address"
 msgstr ""
 
-#: templates/workers/index.jinja:24 templates/workers/index.jinja:47
+#: templates/workers/index.jinja:21 templates/workers/index.jinja:44
 msgid "Account No."
 msgstr ""
 
-#: templates/workers/index.jinja:41
+#: templates/workers/index.jinja:38
 msgid "List of inactive workers"
 msgstr ""

--- a/locale/nb_NO/LC_MESSAGES/django.po
+++ b/locale/nb_NO/LC_MESSAGES/django.po
@@ -3,12 +3,11 @@
 # This file is distributed under the same license as the SPF package.
 # Thor K. Høgås <thor@roht.no>, 2016.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: SPF SPBM v0.1\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-02-20 01:05+0000\n"
+"Report-Msgid-Bugs-To: thor@roht.no\n"
+"POT-Creation-Date: 2017-07-19 18:55+0000\n"
 "PO-Revision-Date: 2016-12-23 03:34+GMT1\n"
 "Last-Translator: Thor K. Høgås <thor@roht.no>\n"
 "Language: Norwegian bokmål\n"
@@ -24,7 +23,7 @@ msgstr "SPF-bruker"
 msgid "SPF-users"
 msgstr "SPF-brukere"
 
-#: spbm/apps/accounts/models.py:12 templates/invoices/index.jinja:144
+#: spbm/apps/accounts/models.py:12 templates/events/view.jinja:34 templates/invoices/index.jinja:142
 msgid "Society"
 msgstr "Forening"
 
@@ -36,12 +35,12 @@ msgstr "Foreningen innad i SPF som denne brukeren har som primærtilknytning."
 msgid "SPF-member connected to {society}"
 msgstr "SPF-medlem tilknyttet til {society}"
 
-#: spbm/apps/norlonn/models.py:13
-msgid "norlÃ¸nn report"
+#: spbm/apps/norlonn/models.py:14
+msgid "norlønn report"
 msgstr "norlønn-rapport"
 
-#: spbm/apps/norlonn/models.py:14
-msgid "norlÃ¸nn reports"
+#: spbm/apps/norlonn/models.py:15
+msgid "norlønn reports"
 msgstr "norlønn-rapporter"
 
 #: spbm/apps/norlonn/views.py:26
@@ -77,157 +76,189 @@ msgstr "Ingenting å generere!"
 msgid "SPBM"
 msgstr "SPBM"
 
-#: spbm/apps/society/models.py:20 spbm/apps/society/models.py:47 spbm/apps/society/models.py:92 spbm/apps/society/models.py:142
+#: spbm/apps/society/models.py:21 spbm/apps/society/models.py:52 spbm/apps/society/models.py:100 spbm/apps/society/models.py:154
 msgid "society"
 msgstr "forening"
 
-#: spbm/apps/society/models.py:21
+#: spbm/apps/society/models.py:22
 msgid "societies"
 msgstr "foreninger"
 
-#: spbm/apps/society/models.py:24 spbm/apps/society/models.py:54 spbm/apps/society/models.py:145
+#: spbm/apps/society/models.py:25 spbm/apps/society/models.py:59 spbm/apps/society/models.py:157
 msgid "name"
 msgstr "navn"
 
-#: spbm/apps/society/models.py:26
+#: spbm/apps/society/models.py:27
 msgid "abbreviated name"
 msgstr "forkortet navn"
 
-#: spbm/apps/society/models.py:28
+#: spbm/apps/society/models.py:29
 msgid "invoice e-mail"
 msgstr "fakturaepost"
 
-#: spbm/apps/society/models.py:30
+#: spbm/apps/society/models.py:31
 msgid "default wage per hour"
 msgstr "standardlønn per time"
 
-#: spbm/apps/society/models.py:31
+#: spbm/apps/society/models.py:32
 msgid "logo"
 msgstr "logo"
 
-#: spbm/apps/society/models.py:43 spbm/apps/society/models.py:202
+#: spbm/apps/society/models.py:44 spbm/apps/society/models.py:233
 msgid "worker"
 msgstr "arbeider"
 
-#: spbm/apps/society/models.py:44
+#: spbm/apps/society/models.py:45
 msgid "workers"
 msgstr "arbeidere"
 
-#: spbm/apps/society/models.py:51
+#: spbm/apps/society/models.py:56
 msgid "active"
 msgstr "aktiv"
 
-#: spbm/apps/society/models.py:52
+#: spbm/apps/society/models.py:57
 msgid "Check off if the worker is still actively working."
 msgstr "Kun kryss av om arbeideren fortsatt jobber aktivt."
 
-#: spbm/apps/society/models.py:55
+#: spbm/apps/society/models.py:60
 msgid "Full name, with first name first."
 msgstr "Fullt navn, med fornavnet først."
 
-#: spbm/apps/society/models.py:57
+#: spbm/apps/society/models.py:62
 msgid "address"
 msgstr "addresse"
 
-#: spbm/apps/society/models.py:58
+#: spbm/apps/society/models.py:63
 msgid "Full address including postal code and area."
 msgstr "Full bostedsadresse, inkl. postkode og område."
 
-#: spbm/apps/society/models.py:61
+#: spbm/apps/society/models.py:66
 msgid "account no."
 msgstr "kontonr."
 
-#: spbm/apps/society/models.py:62
+#: spbm/apps/society/models.py:67
 msgid "Norwegian bank account number, no periods, 11 digits."
 msgstr "Norsk bankkontonummer, uten punktum, 11 siffer."
 
-#: spbm/apps/society/models.py:65
+#: spbm/apps/society/models.py:70
 msgid "person ID"
 msgstr "fødselsnummer"
 
-#: spbm/apps/society/models.py:69
+#: spbm/apps/society/models.py:74
 msgid "norl&oslash;nn number"
 msgstr "norlønn-nummer"
 
-#: spbm/apps/society/models.py:70
+#: spbm/apps/society/models.py:75
 msgid "Employee number in the wage system, Norl&oslash;nn. <strong>Must</strong> exist and be correct!"
 msgstr "Asattnummeret i lønnssystemet Norlønn. <strong>Må</strong> eksistere og være korrekt satt opp!"
 
-#: spbm/apps/society/models.py:84 spbm/apps/society/models.py:161
+#: spbm/apps/society/models.py:91 spbm/apps/society/models.py:180
 msgid "invoice"
 msgstr "faktura"
 
-#: spbm/apps/society/models.py:85
+#: spbm/apps/society/models.py:92
 msgid "invoices"
 msgstr "fakturaer"
 
-#: spbm/apps/society/models.py:94
+#: spbm/apps/society/models.py:102
 msgid "invoice number"
 msgstr "fakturanummer"
 
-#: spbm/apps/society/models.py:96
+#: spbm/apps/society/models.py:104
 msgid "period"
 msgstr "periode"
 
-#: spbm/apps/society/models.py:98
+#: spbm/apps/society/models.py:106
 msgid "invoice paid"
 msgstr "faktura er betalt"
 
-#: spbm/apps/society/models.py:100
+#: spbm/apps/society/models.py:108
 msgid "User which closed the period the invoice belongs to."
 msgstr "Bruker som lukket perioden som fakturaen er en del av."
 
-#: spbm/apps/society/models.py:139
+#: spbm/apps/society/models.py:147
 msgid "event"
 msgstr "arrangement"
 
-#: spbm/apps/society/models.py:140
+#: spbm/apps/society/models.py:148
 msgid "events"
 msgstr "arrangementer"
 
-#: spbm/apps/society/models.py:146
+#: spbm/apps/society/models.py:158
+msgid "Name or title describing the event."
+msgstr "Navn eller tittel som beskriver arrangementet."
+
+#: spbm/apps/society/models.py:159
 msgid "event date"
 msgstr "arrangementdato"
 
-#: spbm/apps/society/models.py:149
+#: spbm/apps/society/models.py:160
+msgid "The date of the event in the format of <em>YYYY-MM-DD</em>."
+msgstr "Arrangementdato på formen av <em>ÅÅÅÅ-MM-DD</em> eller <em>DD-MM-ÅÅÅÅ</em>."
+
+#: spbm/apps/society/models.py:163
 msgid "registered"
 msgstr "registrert"
 
-#: spbm/apps/society/models.py:152
+#: spbm/apps/society/models.py:164
+msgid "Date of event registration."
+msgstr "Registreringsdato til arrangementet."
+
+#: spbm/apps/society/models.py:171
 msgid "processed"
 msgstr "behandlet"
 
-#: spbm/apps/society/models.py:180 templates/invoices/view.jinja:38
-msgid "Total cost"
-msgstr "Total kostnad"
+#: spbm/apps/society/models.py:193 templates/events/index.jinja:28 templates/events/view.jinja:36
+msgid "Total hours"
+msgstr "Sum timer"
 
-#: spbm/apps/society/models.py:194
+#: spbm/apps/society/models.py:204 templates/events/index.jinja:29 templates/events/view.jinja:37 templates/invoices/view.jinja:37
+msgid "Total cost"
+msgstr "Sum kostnad"
+
+#: spbm/apps/society/models.py:225
 msgid "shift"
 msgstr "skift"
 
-#: spbm/apps/society/models.py:195
+#: spbm/apps/society/models.py:226
 msgid "shifts"
 msgstr "skift"
 
-#: spbm/apps/society/models.py:205
+#: spbm/apps/society/models.py:236
 msgid "wage"
 msgstr "timelønn"
 
-#: spbm/apps/society/models.py:208
+#: spbm/apps/society/models.py:240
 msgid "hours"
 msgstr "timer"
 
-#: spbm/apps/society/models.py:214
+#: spbm/apps/society/models.py:247
 msgid "norl&oslash;nn report"
 msgstr "norlønn-rapport"
 
-#: spbm/apps/society/forms/worker.py:14 templates/workers/index.jinja:25 templates/workers/index.jinja:48
+#: spbm/apps/society/models.py:254
+msgid "Worker on shift does not belong to the same society as the event."
+msgstr "Valgt arbeider tilhører ikke samme forening som arrangementet."
+
+#: spbm/apps/society/models.py:256
+msgid "You must select a worker for this shift."
+msgstr "Du må velge en arbeider for dette skiftet."
+
+#: spbm/apps/society/forms/worker.py:14 templates/workers/index.jinja:22 templates/workers/index.jinja:45
 msgid "National ID"
 msgstr "Personnummer"
 
 #: spbm/apps/society/forms/worker.py:15
 msgid "National social security ID, 11 digits."
 msgstr "Fødselsnummer, 11 siffer."
+
+#: spbm/apps/society/views/events.py:54
+msgid "You are not allowed to create events due to lacking permissions."
+msgstr "Du har ikke mulighet til å opprette arrangementer på grunn av manglende tillatelser."
+
+#: spbm/apps/society/views/events.py:81
+msgid "You are not allowed to edit events due to lacking permissions."
+msgstr "Du har ikke mulighet til å redigere arrangementer på grunn av manglende tillatelser."
 
 #: spbm/apps/society/views/invoicing.py:55
 msgid "You <strong>should not</strong> close a period twice in a month without good reason!"
@@ -258,63 +289,63 @@ msgstr "Du har vellykket markert {invoice} som betalt."
 msgid "SPF fee: {percent}% of {event_cost}"
 msgstr "SPF-avgift: {percent}% of {event_cost}"
 
-#: templates/base.jinja:22
+#: templates/base.jinja:27
 msgid "Toggle navigation"
 msgstr "Vis/skjul navigasjon"
 
-#: templates/base.jinja:33
+#: templates/base.jinja:38
 msgid "Your Society"
 msgstr "Foreningen"
 
-#: templates/base.jinja:38
+#: templates/base.jinja:43
 msgid "Bookings"
 msgstr "Utlån / utleie"
 
-#: templates/base.jinja:40
+#: templates/base.jinja:45
 msgid "Workers and registrations"
 msgstr "Arbeidere og registreringer"
 
-#: templates/base.jinja:41 templates/workers/index.jinja:4
+#: templates/base.jinja:46 templates/events/index.jinja:30 templates/workers/index.jinja:2
 msgid "Workers"
 msgstr "Arbeidere"
 
-#: templates/base.jinja:43
+#: templates/base.jinja:48
 msgid "Events and registrations"
 msgstr "Arrangementer og registreringer"
 
-#: templates/base.jinja:44 templates/events/index.jinja:4
+#: templates/base.jinja:49 templates/events/index.jinja:2
 msgid "Events"
 msgstr "Arrangementer"
 
-#: templates/base.jinja:49
+#: templates/base.jinja:54
 msgid "Invoicing"
 msgstr "Fakturering"
 
-#: templates/base.jinja:54
+#: templates/base.jinja:59
 msgid "Wages"
 msgstr "Lønn"
 
-#: templates/base.jinja:62
+#: templates/base.jinja:67
 msgid "Administration"
 msgstr "Administrasjon"
 
-#: templates/base.jinja:67
+#: templates/base.jinja:72
 msgid "Log out of SPFs SPBM"
 msgstr "Logg ut av SPFs SPBM"
 
-#: templates/base.jinja:68
+#: templates/base.jinja:73
 msgid "Logout"
 msgstr "Logg ut"
 
-#: templates/index.jinja:4
+#: templates/index.jinja:2
 msgid "Society overview"
 msgstr "Foreningsoversikt"
 
-#: templates/index.jinja:8
+#: templates/index.jinja:5
 msgid "You're logged into an account associated with:"
 msgstr "Du er logget på en konto assosiert med:"
 
-#: templates/index.jinja:9
+#: templates/index.jinja:6
 msgid "As of right now, this page exactly doesn't really do anything, so take a look at the navigation bar!."
 msgstr ""
 
@@ -358,234 +389,328 @@ msgstr "Logg inn på SPF-siden"
 
 #: templates/errors/unauthorized.jinja:3
 msgid "403 Permission Denied"
-msgstr ""
+msgstr "403 Ikke tillatt"
 
-#: templates/events/add.jinja:4
+#: templates/events/add.jinja:2
 msgid "Add event"
 msgstr "Legg til arrangement"
 
-#: templates/events/add.jinja:30
+#: templates/events/add.jinja:7
 msgid "Create event"
-msgstr "Opprett arrangement"
+msgstr "Opprett arrangementet"
 
-#: templates/events/add.jinja:32 templates/events/add.jinja:33
+#: templates/events/add.jinja:9 templates/events/add.jinja:10
 msgid "Cancel creating this event"
 msgstr "Avbryt opprettelse"
 
-#: templates/events/index.jinja:8
+#: templates/events/delete.jinja:2
+msgid "Confirm deletion of event"
+msgstr "Bekreft sletting av arrangement"
+
+#: templates/events/delete.jinja:10
+msgid "Confirm deletion"
+msgstr "Bekreft sletting"
+
+#: templates/events/delete.jinja:14
+#, python-format
+msgid "Are you sure that you wish to delete the event %(event)s?"
+msgstr "Er du helt sikker på at du ønsker å slette arrangementet %(event)s?"
+
+#: templates/events/delete.jinja:17
+msgid "Cancel deleting and take me back"
+msgstr "Avbryt sletting og take meg tilbake"
+
+#: templates/events/delete.jinja:19
+msgid "Delete the event"
+msgstr "Slett arrangementet"
+
+#: templates/events/edit.jinja:2 templates/events/index.jinja:60 templates/events/view.jinja:19
+msgid "Edit event"
+msgstr "Rediger arrangementet"
+
+#: templates/events/edit.jinja:7
+msgid "Update event with changes"
+msgstr "Oppdater arrangementet med forandringene"
+
+#: templates/events/edit.jinja:9 templates/events/edit.jinja:10
+msgid "Cancel changes"
+msgstr "Forkast endringer"
+
+#: templates/events/form.jinja:8 templates/events/view.jinja:30
+msgid "Event details"
+msgstr "Arrangementdetaljer"
+
+#: templates/events/form.jinja:13
+msgid "Shift workers"
+msgstr "Skiftarbeidere"
+
+#: templates/events/index.jinja:9
 msgid "Add new event"
 msgstr "Legg til nytt arrangement"
 
-#: templates/events/index.jinja:13
+#: templates/events/index.jinja:18
 msgid "Not processed yet"
 msgstr "Ennå ikke behandlet"
 
-#: templates/events/index.jinja:15
+#: templates/events/index.jinja:20
 #, python-format
 msgid "Processed on %(date)s"
 msgstr "Behandlet på %(date)s"
 
-#: templates/events/index.jinja:24
+#: templates/events/index.jinja:26 templates/events/view.jinja:35 templates/invoices/index.jinja:104
+msgid "Date"
+msgstr "Dato"
+
+#: templates/events/index.jinja:27
 msgid "Event"
 msgstr "Arrangement"
 
-#: templates/events/index.jinja:25 templates/workers/index.jinja:22 templates/workers/index.jinja:45
-msgid "Name"
-msgstr "Navn"
+#: templates/events/index.jinja:39 templates/events/utils.jinja:16 templates/events/view.jinja:36
+#, python-format
+msgid "%(hours)sh"
+msgstr "%(hours)st"
 
-#: templates/events/index.jinja:26
-msgid "Hourly"
-msgstr "Timespris"
-
-#: templates/events/index.jinja:27
-msgid "Hours"
-msgstr "Timer"
-
-#: templates/events/index.jinja:28 templates/invoices/view.jinja:53
-msgid "Sum"
-msgstr "Sum"
-
-#: templates/events/index.jinja:37 templates/events/index.jinja:42 templates/invoices/index.jinja:110 templates/invoices/index.jinja:169 templates/invoices/view.jinja:48
-#: templates/invoices/view.jinja:54
+#: templates/events/index.jinja:40 templates/events/utils.jinja:15 templates/events/utils.jinja:17 templates/events/view.jinja:37 templates/invoices/index.jinja:108 templates/invoices/index.jinja:167
+#: templates/invoices/view.jinja:47 templates/invoices/view.jinja:53
 #, python-format
 msgid "NOK %(cost)s"
 msgstr "Kr. %(cost)s"
 
-#: templates/events/index.jinja:42
-msgid "Total"
-msgstr "Totalt"
+#: templates/events/index.jinja:51
+msgid "View the details of the event"
+msgstr "Vis detaljene til arrangementet"
 
-#: templates/invoices/index.jinja:3
+#: templates/events/index.jinja:53 templates/events/view.jinja:2
+msgid "View event"
+msgstr "Vis arrangementet"
+
+#: templates/events/index.jinja:57
+msgid "Edit the event, such as date, workers, and more"
+msgstr "Rediger arrangementets detaljer, som dato, skiftarbeidere, og mer"
+
+#: templates/events/utils.jinja:5 templates/events/view.jinja:33 templates/workers/index.jinja:19 templates/workers/index.jinja:42
+msgid "Name"
+msgstr "Navn"
+
+#: templates/events/utils.jinja:6
+msgid "Hourly"
+msgstr "Timespris"
+
+#: templates/events/utils.jinja:7
+msgid "Hours"
+msgstr "Timer"
+
+#: templates/events/utils.jinja:8 templates/invoices/view.jinja:52
+msgid "Sum"
+msgstr "Sum"
+
+#: templates/events/utils.jinja:9
+msgid "Payrolled"
+msgstr "Utbetalt"
+
+#: templates/events/utils.jinja:25 templates/events/utils.jinja:27
+msgid "Not payrolled"
+msgstr "Ennå ikke utbetalt"
+
+#. small title for viewing an event
+#: templates/events/view.jinja:4
+#, python-format
+msgid "Viewing %(name)s (#%(id)i)"
+msgstr "Viser %(name)s (#%(id)i)"
+
+#: templates/events/view.jinja:22
+msgid "Delete event"
+msgstr "Slett arrangement"
+
+#: templates/events/view.jinja:42
+msgid "Invoicing and wage details"
+msgstr "Faktura- og lønnsdetaljer"
+
+#: templates/events/view.jinja:45
+#, python-format
+msgid "This event has yet to be invoiced to a society. Please see <a href=\"%(invoices)s\" class=\"alert-link\">the invoice section</a> to close the current invoice period."
+msgstr "Dette arrangementet er ennå ikke fakturert til en forening. Gå til <a href=\"%(invoices)s\" class=\"alert-link\">fakturabehandling</a> for å lukke nåværende periode."
+
+#: templates/events/view.jinja:53
+#, python-format
+msgid ""
+"This event has been invoiced to %(society)s, and the wages will be paid to workers as soon as a <a class=\"alert-link\" href=\"%(payroll)s\">payroll report has been created</a> for all valid "
+"workers."
+msgstr ""
+"Dette arrangementet har blitt fakturert til %(society)s, og lønnen vil bli utbetalt til arbeiderne så snart som en <a class=\"alert-link\" href=\"%(payroll)s\">lønnsrapport har blitt opprettet</a> "
+"for alle gyldige oppsatte arbeidere."
+
+#: templates/events/view.jinja:63
+msgid "Shift details"
+msgstr "Skiftdetaljer"
+
+#: templates/invoices/index.jinja:2
 msgid "Invoice Management"
 msgstr "Fakturabehandling"
 
-#: templates/invoices/index.jinja:23
+#: templates/invoices/index.jinja:21
 #, python-format
 msgid "%(days)s days"
 msgstr "%(days)s dager"
 
-#: templates/invoices/index.jinja:31
+#: templates/invoices/index.jinja:29
 msgid "Period status"
 msgstr "Periodestatus"
 
-#: templates/invoices/index.jinja:33
+#: templates/invoices/index.jinja:31
 #, python-format
 msgid "%(num)d unprocessed event"
 msgid_plural "%(num)d unprocessed events"
 msgstr[0] "%(num)d ubehandlet arrangement"
 msgstr[1] "%(num)d ubehandlede arrangementer"
 
-#: templates/invoices/index.jinja:44
+#: templates/invoices/index.jinja:42
 msgid "There are unprocessed events, which means you can close the period, if it is the right time of month."
 msgstr "Det er ubehandlede arrangementer, som betyr at du kan lukke perioden, hvis det er det rette tidspunktet i måneden."
 
-#: templates/invoices/index.jinja:51
+#: templates/invoices/index.jinja:49
 msgid "Close period"
 msgstr "Lukk periode"
 
-#: templates/invoices/index.jinja:52 templates/norlonn/index.jinja:42
+#: templates/invoices/index.jinja:50 templates/norlonn/index.jinja:41
 msgid "Not easily reversible!"
 msgstr "Vanskelig å angre!"
 
-#: templates/invoices/index.jinja:56
+#: templates/invoices/index.jinja:54
 msgid "Remember to only close the invoice period <strong>max once a month, on the 15th</strong>."
 msgstr "Husk å kun lukke fakturaperioden <strong>maks én gang i måneden, på den 15.</strong>"
 
-#: templates/invoices/index.jinja:65 templates/invoices/index.jinja:122
+#: templates/invoices/index.jinja:63 templates/invoices/index.jinja:120
 msgid "So far, so good!"
 msgstr "Enn så lenge er alt greit!"
 
-#: templates/invoices/index.jinja:67
+#: templates/invoices/index.jinja:65
 msgid "There are no unprocessed events currently registered. You can register some events if you wish, <em>or</em> wait until next month."
 msgstr "Det er ingen ubehandlede arrangementer registrert for øyeblikket. Registrer noen, <em>eller</em> vent til neste måned."
 
-#: templates/invoices/index.jinja:79
+#: templates/invoices/index.jinja:77
 msgid "Unpaid invoices"
 msgstr "Ubetalte fakturaer"
 
-#: templates/invoices/index.jinja:88
+#: templates/invoices/index.jinja:86
 msgid "The following invoices have yet to be paid, and will affect the next payroll thusly."
 msgstr "Følgende fakturaer er fortsatt ubetalt, og vil dermed påvirke neste lønnsutbetaling."
 
-#: templates/invoices/index.jinja:101
+#: templates/invoices/index.jinja:99
 msgid "Mark as paid"
 msgstr "Markér som betalt"
 
-#: templates/invoices/index.jinja:106
-msgid "Date"
-msgstr "Dato"
-
-#: templates/invoices/index.jinja:109
+#: templates/invoices/index.jinja:107
 msgid "Amount"
 msgstr "Sum"
 
-#: templates/invoices/index.jinja:119
+#: templates/invoices/index.jinja:117
 msgid "There aren't any unpaid invoices! That's great!"
 msgstr "Det er ingen ubetalte fakturaer! Flotters!"
 
-#: templates/invoices/index.jinja:130
+#: templates/invoices/index.jinja:128
 msgid "Complete invoice overview"
 msgstr "Komplett fakturaoversikt"
 
-#: templates/invoices/index.jinja:135
+#: templates/invoices/index.jinja:133
 msgid "Overview over all the various invoices that <em>should have</em> been sent to the respective societies."
 msgstr "Oversikt over alle de forskjellige fakturaene som <em>burde</em> ha blitt sendt til de forskjellige foreningene."
 
-#: templates/invoices/index.jinja:143
+#: templates/invoices/index.jinja:141
 msgid "Period"
 msgstr "Periode"
 
-#: templates/invoices/index.jinja:145
+#: templates/invoices/index.jinja:143
 msgid "Invoice sum"
 msgstr "Fakturasum"
 
-#: templates/invoices/index.jinja:146
+#: templates/invoices/index.jinja:144
 msgid "Paid?"
 msgstr "Betalt?"
 
-#: templates/invoices/index.jinja:147
+#: templates/invoices/index.jinja:145
 msgid "Actions"
 msgstr "Handlinger"
 
-#: templates/invoices/index.jinja:172 templates/workers/index.jinja:35
+#: templates/invoices/index.jinja:170 templates/workers/index.jinja:32
 msgid "Yes"
 msgstr "Ja"
 
-#: templates/invoices/index.jinja:174 templates/workers/index.jinja:35
+#: templates/invoices/index.jinja:172 templates/workers/index.jinja:32
 msgid "No"
 msgstr "Nei"
 
-#: templates/invoices/index.jinja:180
+#: templates/invoices/index.jinja:178
 msgid "View the details of the invoice"
 msgstr "Vis detaljene til fakturaen"
 
-#: templates/invoices/index.jinja:182
+#: templates/invoices/index.jinja:180
 msgid "View invoice"
 msgstr "Vis faktura"
 
-#: templates/invoices/index.jinja:185
+#: templates/invoices/index.jinja:183
 msgid "View PDF"
 msgstr "Vis PDF"
 
-#: templates/invoices/index.jinja:187
+#: templates/invoices/index.jinja:185
 msgid "View invoice PDF"
 msgstr "Vis PDF av fakturaen"
 
-#: templates/invoices/view.jinja:4
+#: templates/invoices/view.jinja:2
 #, python-format
 msgid "Invoice #%(id)s: %(date)s %(society)s"
 msgstr "Faktura #%(id)s: %(date)s %(society)s"
 
-#: templates/invoices/view.jinja:13
+#: templates/invoices/view.jinja:12
 #, python-format
 msgid "Invoiced at %(period)s"
 msgstr "Fakturert på %(period)s"
 
-#: templates/invoices/view.jinja:17
+#: templates/invoices/view.jinja:16
 #, python-format
 msgid "%(society)s"
 msgstr "%(society)s"
 
-#: templates/invoices/view.jinja:26
+#: templates/invoices/view.jinja:25
 #, python-format
 msgid "Period closed by %(user)s"
 msgstr "Periode lukket av %(user)s"
 
-#: templates/invoices/view.jinja:31
+#: templates/invoices/view.jinja:30
 #, python-format
 msgid "Overview over events and costs associated with invoice number %(id)d."
 msgstr "Oversikt over arrangement og kostnader assosiert med fakturanr. %(id)d."
 
-#: templates/invoices/view.jinja:35
+#: templates/invoices/view.jinja:34
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: templates/invoices/view.jinja:36
+#: templates/invoices/view.jinja:35
 msgid "Count"
 msgstr "Antall"
 
-#: templates/invoices/view.jinja:37
+#: templates/invoices/view.jinja:36
 msgid "Unit cost"
 msgstr "Enhetskostnad"
 
-#: templates/invoices/view.jinja:60
+#: templates/invoices/view.jinja:59
 msgid "Return to invoice overview"
 msgstr "Gå tilbake til fakturaoversikten"
 
 #. Title for reports page.
-#: templates/norlonn/index.jinja:5
+#: templates/norlonn/index.jinja:4
 msgid "Wage Reports"
 msgstr "Lønnsrapporter"
 
-#: templates/norlonn/index.jinja:10
+#: templates/norlonn/index.jinja:9
 msgid "Access to wage reports for importing into the <em>Norlønn</em> payroll system."
 msgstr "Tilgang til lønnsrapporter for import inn i lønnssystemet <em>Norlønn</em>."
 
-#: templates/norlonn/index.jinja:17
+#: templates/norlonn/index.jinja:16
 msgid "Current report errors"
 msgstr "Eksisterende rapportfeil"
 
-#: templates/norlonn/index.jinja:19
+#: templates/norlonn/index.jinja:18
 msgid ""
 "There are some errors present. Please fix the errors before you attempt generating a report, as to avoid workers missing out on their wages. If the errors are associated with a different society "
 "than yours, get in touch with them over the mailing list."
@@ -593,15 +718,15 @@ msgstr ""
 "Det er noen feil med arbeidere eller faktura. Rett på disse feilene før du forsøker å opprette en rapport, slik at ingen arbeidere går glipp av deres lønn.Hvis feilene er assosiert med en annen "
 "forening, så anbefales at det at du <strong>kontakter dem</strong> med e-postlisten."
 
-#: templates/norlonn/index.jinja:41
+#: templates/norlonn/index.jinja:40
 msgid "Generate new wage report"
 msgstr "Generér ny lønnsrapport"
 
-#: templates/norlonn/index.jinja:48
+#: templates/norlonn/index.jinja:47
 msgid "Existing reports"
 msgstr "Eksisterende rapporter"
 
-#: templates/norlonn/index.jinja:51
+#: templates/norlonn/index.jinja:50
 msgid ""
 "The following is the list of the payment reports that have been created in the past. They detail the amount of money and payments for each worker, and should only <strong>be imported once</strong> "
 "into Norlønn."
@@ -619,45 +744,48 @@ msgstr "Rapportelementer med feil"
 msgid "Successful elements"
 msgstr "Vellykkede elementer"
 
-#: templates/workers/edit.jinja:3
+#: templates/workers/edit.jinja:2
 msgid "Edit worker"
 msgstr "Rediger arbeider"
 
-#: templates/workers/edit.jinja:17
+#: templates/workers/edit.jinja:16
 msgid "Save changes"
 msgstr "Lagre endringer"
 
-#: templates/workers/edit.jinja:19
+#: templates/workers/edit.jinja:18
 msgid "Cancel editing this worker"
 msgstr "Avbryt redigering"
 
-#: templates/workers/edit.jinja:20
+#: templates/workers/edit.jinja:19
 msgid "Cancel editing & changes"
 msgstr "Avbryt redigering & endringer"
 
-#: templates/workers/index.jinja:8
+#: templates/workers/index.jinja:5
 msgid "Add new worker"
 msgstr "Legg til ny arbeider"
 
-#: templates/workers/index.jinja:14
+#: templates/workers/index.jinja:11
 msgid "Add worker"
 msgstr "Legg til arbeider"
 
-#: templates/workers/index.jinja:18
+#: templates/workers/index.jinja:15
 msgid "List of workers"
 msgstr "Oversikt over arbeidere"
 
-#: templates/workers/index.jinja:23 templates/workers/index.jinja:46
+#: templates/workers/index.jinja:20 templates/workers/index.jinja:43
 msgid "Address"
 msgstr "Adresse"
 
-#: templates/workers/index.jinja:24 templates/workers/index.jinja:47
+#: templates/workers/index.jinja:21 templates/workers/index.jinja:44
 msgid "Account No."
 msgstr "Kontonr."
 
-#: templates/workers/index.jinja:41
+#: templates/workers/index.jinja:38
 msgid "List of inactive workers"
 msgstr "Oversikt over inaktive arbeidere"
+
+#~ msgid "Total"
+#~ msgstr "Totalt"
 
 #~ msgid "Financials"
 #~ msgstr "Økonomi"

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,6 @@ uwsgi==2.0.15
 
 # Sane relative dates
 python-dateutil==2.6.0
+
+# Extra class-based generic views
+django-extra-views

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Main framework
 Django>=1.11,<1.12
 django-jinja==2.2.2
+django-debug-toolbar
 
 # Data
 psycopg2==2.6.2
@@ -10,6 +11,7 @@ jinja2==2.9.6
 puente==0.5
 markupsafe==1.0
 pytz==2017.02
+
 # PDF-generation
 reportlab==3.4.0
 # Localisation and handling local input

--- a/spbm/apps/norlonn/models.py
+++ b/spbm/apps/norlonn/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.formats import localize
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -16,7 +17,7 @@ class NorlonnReport(models.Model):
     date = models.DateField()
 
     def __str__(self):
-        return str(self.date)
+        return str(localize(self.date))
 
     class Meta:
         permissions = (

--- a/spbm/apps/society/admin/events.py
+++ b/spbm/apps/society/admin/events.py
@@ -21,7 +21,7 @@ def is_readonly(obj: object) -> bool:
         # If we're looking from an Invoice, we exist, thus it's read-only.
         return True
     else:
-        return obj is not None and obj.processed
+        return False
 
 
 class ReadOnlyProtection:

--- a/spbm/apps/society/admin/events.py
+++ b/spbm/apps/society/admin/events.py
@@ -72,12 +72,13 @@ class EventInline(ReadOnlyProtection, admin.TabularInline):
         else:
             super().get_readonly_fields(request, obj)
 
+
 @admin.register(Event)
 class EventAdmin(admin.ModelAdmin):
     date_hierarchy = 'date'
     inlines = [ShiftInline]
     list_filter = ('society', 'invoice',)
-    list_display = ('__str__', 'get_cost', 'registered', 'date', 'processed',)
+    list_display = ('__str__', 'registered', 'date', 'hours', 'cost', 'processed',)
     exclude = ('invoice',)
 
     def get_readonly_fields(self, request, obj=None):
@@ -125,5 +126,3 @@ class EventAdmin(admin.ModelAdmin):
             return qs.filter(society=request.user.spfuser.society)
         else:
             return qs.none()
-
-

--- a/spbm/apps/society/fixtures/Worker.json
+++ b/spbm/apps/society/fixtures/Worker.json
@@ -37,5 +37,18 @@
       "person_id": "01020334589",
       "norlonn_number": null
     }
+  },
+  {
+    "model": "society.worker",
+    "pk": 4,
+    "fields": {
+      "society": 2,
+      "active": true,
+      "name": "Nicolas H. Normann",
+      "address": "Bygata 2, 1378 Nesøya",
+      "account_no": "",
+      "person_id": "01020334589",
+      "norlonn_number": null
+    }
   }
 ]

--- a/spbm/apps/society/forms/events.py
+++ b/spbm/apps/society/forms/events.py
@@ -1,30 +1,32 @@
-from django.forms import DateInput
-from django.forms import ModelForm
+from django import forms
 
 from spbm.apps.society.models import Worker, Event, Shift
 
 
-class MyDateInput(DateInput):
+class DateInput(forms.DateInput):
     input_type = 'date'
 
 
-class EventForm(ModelForm):
-    def __init__(self, *args, **kwargs):
-        super(EventForm, self).__init__(*args, **kwargs)
-        self.fields['date'].widget = MyDateInput(attrs={'class': 'date'})
-
+class EventForm(forms.ModelForm):
     class Meta:
         model = Event
         fields = ['name', 'date']
+        widgets = {
+            'date': DateInput(attrs={'class': 'date'})
+        }
 
 
 def make_shift_base(society):
     """ Takes a society and returns a Shift form with initial data populated based of society defaults """
 
-    class ShiftForm(ModelForm):
+    class ShiftForm(forms.ModelForm):
         class Meta:
             model = Shift
             exclude = ['norlonn_report']
+            widgets = {
+                'wage': forms.NumberInput(attrs={'step': 1}),
+                'hours': forms.NumberInput(attrs={'step': '0.25'})
+            }
 
         def __init__(self, *args, **kwargs):
             super(ShiftForm, self).__init__(*args, initial={'wage': society.default_wage}, **kwargs)

--- a/spbm/apps/society/forms/events.py
+++ b/spbm/apps/society/forms/events.py
@@ -1,7 +1,9 @@
 from django.forms import ModelChoiceField, DecimalField, DateInput
-from django.forms import ModelForm, Form
+from django.forms import ModelForm, Form, BaseModelFormSet
+from extra_views import InlineFormSet
 
-from spbm.apps.society.models import Worker, Event
+from helpers.auth import user_society
+from spbm.apps.society.models import Worker, Event, Shift
 
 
 class MyDateInput(DateInput):
@@ -18,14 +20,20 @@ class EventForm(ModelForm):
         fields = ['name', 'date']
 
 
-def MakeShiftBase(society):
-    class ShiftForm(Form):
+def make_shift_base(society):
+    """ Takes a society and returns a Shift form with initial data populated based of society defaults """
+
+    class ShiftForm(ModelForm):
+        class Meta:
+            model = Shift
+            exclude = ['norlonn_report']
+
         def __init__(self, *args, **kwargs):
             super(ShiftForm, self).__init__(*args, initial={'wage': society.default_wage}, **kwargs)
-            self.fields['worker'].queryset = Worker.objects.filter(society=society, active=1)
-
-        worker = ModelChoiceField(queryset=Worker.objects.filter(society=society))
-        wage = DecimalField(max_digits=10, decimal_places=2)
-        hours = DecimalField(max_digits=10, decimal_places=2)
+            self.fields['worker'].queryset = Worker.objects.filter(society=society, active=True)
 
     return ShiftForm
+
+
+
+

--- a/spbm/apps/society/forms/events.py
+++ b/spbm/apps/society/forms/events.py
@@ -1,8 +1,6 @@
-from django.forms import ModelChoiceField, DecimalField, DateInput
-from django.forms import ModelForm, Form, BaseModelFormSet
-from extra_views import InlineFormSet
+from django.forms import DateInput
+from django.forms import ModelForm
 
-from helpers.auth import user_society
 from spbm.apps.society.models import Worker, Event, Shift
 
 

--- a/spbm/apps/society/models.py
+++ b/spbm/apps/society/models.py
@@ -149,16 +149,19 @@ class Event(models.Model):
 
     class EventManager(models.Manager):
         def get_queryset(self):
-            return super().get_queryset().prefetch_related('shifts__worker')
+            return super().get_queryset().prefetch_related('shifts__worker', 'society')
 
     society = models.ForeignKey(Society, null=False, verbose_name=_('society'), related_name="society",
                                 on_delete=models.PROTECT)
     name = models.CharField(max_length=100,
-                            verbose_name=_('name'))
-    date = models.DateField(verbose_name=_('event date'))
+                            verbose_name=_('name'),
+                            help_text=_('Name or title describing the event.'))
+    date = models.DateField(verbose_name=_('event date'),
+                            help_text=_('The date of the event in the format of <em>YYYY-MM-DD</em>.'))
     registered = models.DateField(auto_now_add=True,
                                   editable=False,
-                                  verbose_name=_('registered'))
+                                  verbose_name=_('registered'),
+                                  help_text=_('Date of event registration.'))
     ''' 'processed' and 'invoice' are very tightly coupled together.
     Why exactly are both needed? Any invoice is processed on an exact date. If it shouldn't be part of an invoice,
     then it is not really processed anyway. '''

--- a/spbm/apps/society/models.py
+++ b/spbm/apps/society/models.py
@@ -251,9 +251,9 @@ class Shift(models.Model):
     def clean(self):
         try:
             if self.worker.society != self.event.society:
-                raise ValidationError("Worker on shift does not belong to the same society as the event")
+                raise ValidationError(_('Worker on shift does not belong to the same society as the event.'))
         except:
-            raise ValidationError("No worker or event")
+            raise ValidationError(_('You must select a worker for this shift.'))
 
     def get_total(self):
         return (self.wage * self.hours).quantize(Decimal(".01"))

--- a/spbm/apps/society/models.py
+++ b/spbm/apps/society/models.py
@@ -44,6 +44,10 @@ class Worker(models.Model):
         verbose_name = _('worker')
         verbose_name_plural = _('workers')
 
+    class WorkerManager(models.Manager):
+        def get_queryset(self):
+            return super().get_queryset().select_related('society')
+
     society = models.ForeignKey(Society,
                                 verbose_name=_('society'),
                                 on_delete=models.PROTECT,
@@ -71,6 +75,8 @@ class Worker(models.Model):
                                          help_text=mark_safe_lazy(_(
                                              "Employee number in the wage system, Norl&oslash;nn. " +
                                              "<strong>Must</strong> exist and be correct!")))
+
+    objects = WorkerManager()
 
     def __str__(self):
         return self.name + " (" + self.society.shortname + ")"
@@ -141,6 +147,10 @@ class Event(models.Model):
         verbose_name = _('event')
         verbose_name_plural = _('events')
 
+    class EventManager(models.Manager):
+        def get_queryset(self):
+            return super().get_queryset().prefetch_related('shifts__worker')
+
     society = models.ForeignKey(Society, null=False, verbose_name=_('society'), related_name="society",
                                 on_delete=models.PROTECT)
     name = models.CharField(max_length=100,
@@ -165,6 +175,8 @@ class Event(models.Model):
                                 on_delete=models.PROTECT,
                                 related_name="events",
                                 verbose_name=_('invoice'))
+
+    objects = EventManager()
 
     @property
     def hours(self):

--- a/spbm/apps/society/tests/__init__.py
+++ b/spbm/apps/society/tests/__init__.py
@@ -1,10 +1,17 @@
 from django.conf import settings
+from django.test import SimpleTestCase
 
 test_fixtures = ['Event', 'Invoice', 'Shift', 'Society', 'Worker', 'NorlonnReport', 'User',
                  'SpfUser']
-
 
 # Turn on the django-jinja template debug to provide response.context in the client.
 # NOTE: Do *not* change any other settings on-the-fly. This one only affects this exact issue,
 #       and as such it's safe to edit. Otherwise Django settings are _immutable_.
 settings.TEMPLATES[0]['OPTIONS']['debug'] = True
+
+
+class SPFTest(SimpleTestCase):
+    def assertMessagesContains(self, response, needle: str, msg=None):
+        if not any(needle in str(x) for x in list(response.context['messages'])):
+            msg = self._formatMessage(msg, "'%s' not contained in messages" % needle)
+            raise self.failureException(msg)

--- a/spbm/apps/society/tests/test_events.py
+++ b/spbm/apps/society/tests/test_events.py
@@ -1,0 +1,94 @@
+from django.contrib.auth.models import User
+from django.db import IntegrityError
+from django.test import TestCase
+from django.urls import reverse
+
+from . import test_fixtures
+from ..models import Event, Society
+from ...accounts.models import SpfUser
+
+
+class EventLoggedInTests(TestCase):
+    fixtures = test_fixtures
+    HTTP_OK = 200
+
+    def setUp(self):
+        self.user = User(username='kungfury')
+        self.user.save()
+        self.spf_user = SpfUser(user=self.user, society=Society.objects.get(pk=2))
+        self.spf_user.save()
+        self.client.force_login(self.user)
+
+    def test_index(self):
+        """
+        Test the events index page returns a 200 with an empty list of processed events.
+        """
+        events_index = self.client.get(reverse('events'), follow=True)
+        self.assertEqual(events_index.status_code, self.HTTP_OK)
+        self.assertEqual(events_index.context['processed'].count(), 0)
+
+    def test_can_access_logged_in(self):
+        """
+        Test that we can access these pages being logged in.
+        """
+        [self.assertEqual(self.client.get(reverse(view), follow=True).status_code, self.HTTP_OK,
+                          "Incorrect HTTP response given!")
+         for view in ['events', 'events-add']]
+
+    def test_add_event(self):
+        """
+        Test that we can add an event.
+        """
+        event_data = {
+            'event-0-name': "Magical Test Event",
+            'event-0-date': "2017-01-25",
+            'event-TOTAL_FORMS': 1,
+            'event-INITIAL_FORMS': 0,
+            'shift-0-worker': 3,
+            'shift-0-wage': 128.00,
+            'shift-0-hours': 8,
+            'shift-TOTAL_FORMS': 1,
+            'shift-INITIAL_FORMS': 0
+        }
+        adding_event = self.client.post(reverse('events-add'), event_data, follow=True)
+        self.assertEqual(adding_event.status_code, self.HTTP_OK)
+        last_event = Event.objects.last()
+        self.assertEqual(last_event.name, "Magical Test Event")
+        self.assertTrue(last_event.date)
+        self.assertEqual(last_event.shifts.count(), 1)
+
+    def test_add_event_duplicate_worker(self):
+        """
+        Test that we fail when adding a worker twice to an event.
+        """
+        event_data = {
+            'event-0-name': "Magical Test Event",
+            'event-0-date': "2017-01-25",
+            'event-TOTAL_FORMS': 1,
+            'event-INITIAL_FORMS': 0,
+            'shift-0-worker': 3,
+            'shift-0-wage': 128.00,
+            'shift-0-hours': 8,
+            'shift-1-worker': 3,
+            'shift-1-wage': 128.00,
+            'shift-1-hours': 8,
+            'shift-TOTAL_FORMS': 2,
+            'shift-INITIAL_FORMS': 0
+        }
+        with self.assertRaises(IntegrityError):
+            added_event = self.client.post(reverse('events-add'), event_data, follow=True)
+
+
+class EventLoggedOutTests(TestCase):
+    def test_cannot_access_logged_out(self):
+        """
+        Verify that endpoints cannot be accessed while logged out.
+        In other words, verify that they forward to the login screen.
+        """
+        from ..urls import event_urls
+        for view in event_urls:
+            response = self.client.get(reverse(view.name))
+            self.assertEqual(response.status_code,
+                             302,
+                             "Did not receive expected HTTP UNAUTHORIZED")
+            self.assertTrue("/accounts/login" in response.url)

--- a/spbm/apps/society/tests/test_invoicing.py
+++ b/spbm/apps/society/tests/test_invoicing.py
@@ -37,7 +37,7 @@ class InvoicingTests(SPFTest, TestCase):
         response = self.client.get(reverse('invoice-view', kwargs={'society_name': 'CYB', 'date': '2016-07-17'}))
         self.assertTrue(response.status_code, 200)
         # Is there a mention of the SPF-fee?
-        self.assertInHTML("SPF", response)
+        self.assertContains(response, "SPF")
 
     def test_get_unpaid_invoices(self):
         """

--- a/spbm/apps/society/tests/test_invoicing.py
+++ b/spbm/apps/society/tests/test_invoicing.py
@@ -30,6 +30,15 @@ class InvoicingTests(SPFTest, TestCase):
         response = self.client.get(reverse('invoices'))
         self.assertEqual(len(response.context['all_invoices']), len(Invoice.objects.all()))
 
+    def test_view_an_invoice(self):
+        """
+        Show an invoice in HTML-style.
+        """
+        response = self.client.get(reverse('invoice-view', kwargs={'society_name': 'CYB', 'date': '2016-07-17'}))
+        self.assertTrue(response.status_code, 200)
+        # Is there a mention of the SPF-fee?
+        self.assertInHTML("SPF", response)
+
     def test_get_unpaid_invoices(self):
         """
         Show unpaid invoices available for payment.

--- a/spbm/apps/society/tests/test_invoicing.py
+++ b/spbm/apps/society/tests/test_invoicing.py
@@ -2,12 +2,12 @@ from django.contrib.auth.models import User, Permission
 from django.test import TestCase
 from django.urls import reverse
 
-from . import test_fixtures
+from . import test_fixtures, SPFTest
 from ..models import Invoice, Society, Event
 from ...accounts.models import SpfUser
 
 
-class InvoicingTests(TestCase):
+class InvoicingTests(SPFTest, TestCase):
     fixtures = test_fixtures
 
     def setUp(self):

--- a/spbm/apps/society/urls.py
+++ b/spbm/apps/society/urls.py
@@ -28,9 +28,7 @@ workers_urls = [
 event_urls = [
     url(r'^$', events.index, name='events'),
     url(r'^add/$', events.EventCreateView.as_view(), name='events-add'),
-    url(r'^view/(?P<pk>\d+)$', events.EventUpdateView.as_view(), name='events-view'),
-    url(r'^' + society_match + r'$', events.index, name='events'),
-    url(r'^' + society_match + r'add/$', events.add, name='events-add'),
+    url(r'^edit/(?P<pk>\d+)$', events.EventUpdateView.as_view(), name='events-view'),
 ]
 
 invoicing_urls = [

--- a/spbm/apps/society/urls.py
+++ b/spbm/apps/society/urls.py
@@ -28,8 +28,9 @@ workers_urls = [
 event_urls = [
     url(r'^$', events.index, name='events'),
     url(r'^add/$', events.EventCreateView.as_view(), name='event-add'),
-    url(r'^edit/(?P<pk>\d+)$', events.EventUpdateView.as_view(), name='event-edit'),
     url(r'^view/(?P<pk>\d+)$', events.EventViewView.as_view(), name='event-view'),
+    url(r'^edit/(?P<pk>\d+)$', events.EventUpdateView.as_view(), name='event-edit'),
+    url(r'^delete/(?P<pk>\d+)$', events.EventDeleteView.as_view(), name='event-delete'),
 ]
 
 invoicing_urls = [

--- a/spbm/apps/society/urls.py
+++ b/spbm/apps/society/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls import url, include
 from spbm.apps.norlonn import views as wages
 
 from .views import views_overview as overview, views_workers as workers, \
-    views_events as events, invoicing as invoicing
+    events, invoicing
 from .views.views_overview import index as standard_index
 
 # Our *pre-made* (*cough*) bit of URL that specifies which society we're in.
@@ -26,9 +26,10 @@ workers_urls = [
 ]
 
 event_urls = [
-    url(r'^$', events.redirect_society, name="events"),
-    url(r'^' + society_match + r'$', events.index, name="events-society"),
-    url(r'^' + society_match + r'add/$', events.add),
+    url(r'^$', events.index, name='events'),
+    url(r'^add/$', events.EventAddView.as_view(), name='events-add'),
+    url(r'^' + society_match + r'$', events.index, name='events'),
+    url(r'^' + society_match + r'add/$', events.add, name='events-add'),
 ]
 
 invoicing_urls = [

--- a/spbm/apps/society/urls.py
+++ b/spbm/apps/society/urls.py
@@ -27,7 +27,8 @@ workers_urls = [
 
 event_urls = [
     url(r'^$', events.index, name='events'),
-    url(r'^add/$', events.EventAddView.as_view(), name='events-add'),
+    url(r'^add/$', events.EventCreateView.as_view(), name='events-add'),
+    url(r'^view/(?P<pk>\d+)$', events.EventUpdateView.as_view(), name='events-view'),
     url(r'^' + society_match + r'$', events.index, name='events'),
     url(r'^' + society_match + r'add/$', events.add, name='events-add'),
 ]

--- a/spbm/apps/society/urls.py
+++ b/spbm/apps/society/urls.py
@@ -27,8 +27,9 @@ workers_urls = [
 
 event_urls = [
     url(r'^$', events.index, name='events'),
-    url(r'^add/$', events.EventCreateView.as_view(), name='events-add'),
-    url(r'^edit/(?P<pk>\d+)$', events.EventUpdateView.as_view(), name='events-view'),
+    url(r'^add/$', events.EventCreateView.as_view(), name='event-add'),
+    url(r'^edit/(?P<pk>\d+)$', events.EventUpdateView.as_view(), name='event-edit'),
+    url(r'^view/(?P<pk>\d+)$', events.EventViewView.as_view(), name='event-view'),
 ]
 
 invoicing_urls = [

--- a/spbm/apps/society/views/invoicing.py
+++ b/spbm/apps/society/views/invoicing.py
@@ -153,8 +153,8 @@ def view_invoice(request, society_name, date):
 
     # Go through all the events
     for event in events:
-        event_hours = event.get_hours()
-        event_cost = event.get_cost()
+        event_hours = event.hours
+        event_cost = event.cost
         items.append({
             'description': "{date}: {title}".format(date=event.date, title=event.name),
             'count': event_hours,

--- a/spbm/apps/society/views/views_workers.py
+++ b/spbm/apps/society/views/views_workers.py
@@ -6,10 +6,10 @@ from django.views.generic import UpdateView
 from spbm.helpers.auth import user_allowed_society
 from spbm.apps.society.forms.worker import WorkerForm, WorkerEditForm
 from spbm.apps.society.models import Society, Worker
-from spbm.helpers.mixins import LoggedInPermissionsMixin
+from spbm.helpers.mixins import LoginAndPermissionRequiredMixin
 
 
-class EditWorker(LoggedInPermissionsMixin, UpdateView):
+class EditWorker(LoginAndPermissionRequiredMixin, UpdateView):
     """
     Provides a simple editing interface for workers using #UpdateView.
     """

--- a/spbm/helpers/auth.py
+++ b/spbm/helpers/auth.py
@@ -6,3 +6,6 @@ def user_allowed_society(usr, soc):
         return True
 
     return False
+
+def user_society(request):
+    return request.user.spfuser.society

--- a/spbm/helpers/mixins.py
+++ b/spbm/helpers/mixins.py
@@ -3,17 +3,17 @@ from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
 
 
-class LoggedInPermissionsMixin(PermissionRequiredMixin):
+class LoginAndPermissionRequiredMixin(PermissionRequiredMixin):
     """
     Custom mixin to merge login and permission required.
     """
 
     def dispatch(self, request, *args, **kwargs):
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             return redirect_to_login(request.get_full_path(),
                                      self.get_login_url(), self.get_redirect_field_name(),
                                      )
         if not self.has_permission():
             # We could also use "return self.handle_no_permission()" here
             raise PermissionDenied(self.get_permission_denied_message())
-        return super(LoggedInPermissionsMixin, self).dispatch(request, *args, **kwargs)
+        return super(LoginAndPermissionRequiredMixin, self).dispatch(request, *args, **kwargs)

--- a/spbm/helpers/mixins.py
+++ b/spbm/helpers/mixins.py
@@ -1,12 +1,13 @@
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.views import redirect_to_login
-from django.core.exceptions import PermissionDenied
 
 
 class LoginAndPermissionRequiredMixin(PermissionRequiredMixin):
     """
     Custom mixin to merge login and permission required.
     """
+
+    raise_exception = True
 
     def dispatch(self, request, *args, **kwargs):
         if not request.user.is_authenticated:
@@ -15,5 +16,6 @@ class LoginAndPermissionRequiredMixin(PermissionRequiredMixin):
                                      )
         if not self.has_permission():
             # We could also use "return self.handle_no_permission()" here
-            raise PermissionDenied(self.get_permission_denied_message())
+            # raise PermissionDenied(self.get_permission_denied_message())
+            return self.handle_no_permission()
         return super(LoginAndPermissionRequiredMixin, self).dispatch(request, *args, **kwargs)

--- a/spbm/settings.py
+++ b/spbm/settings.py
@@ -129,8 +129,6 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
-                # Added from old SPF
-                # 'django.template.context_processors.request'
             ]
         }
     },

--- a/spbm/settings.py
+++ b/spbm/settings.py
@@ -37,6 +37,7 @@ DEBUG = True
 
 # When Debug is False, ALLOWED_HOSTS must be configured correctly.
 ALLOWED_HOSTS = []
+INTERNAL_IPS = ['127.0.0.1']
 ROOT_URLCONF = 'spbm.urls'
 WSGI_APPLICATION = 'spbm.wsgi.application'
 
@@ -55,6 +56,7 @@ INSTALLED_APPS = (
     'spbm.apps.society',
     'spbm.apps.accounts',
     'spbm.apps.norlonn',
+    'debug_toolbar'
 )
 
 # Middleware onion layers
@@ -64,10 +66,11 @@ MIDDLEWARE = (
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware'
 )
 
 # Database

--- a/spbm/urls.py
+++ b/spbm/urls.py
@@ -7,8 +7,13 @@ from spbm.apps.society.views import PermissionDeniedView
 
 handler403 = PermissionDeniedView.as_view()
 
-urlpatterns = [
-                  url(r'^admin/', admin.site.urls),
-                  url(r'^accounts/', include('spbm.apps.accounts.urls')),
-                  url(r'^', include('spbm.apps.society.urls')),
-              ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+urlpatterns = [url(r'^admin/', admin.site.urls),
+               url(r'^accounts/', include('spbm.apps.accounts.urls')),
+               url(r'^', include('spbm.apps.society.urls')),
+               ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# Django Debug Toolbar, and other debug-related URLconfs
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [url(r'^__debug__/', include(debug_toolbar.urls)),
+                   ] + urlpatterns

--- a/static/css/spbm.css
+++ b/static/css/spbm.css
@@ -45,3 +45,21 @@ Table paddings for wide-spanning row headers
 .table .table-sum > td {
     padding-top: 1em;
 }
+
+/*
+Vertical spacing when stacking forms
+ */
+.form-stack.form-group [class*="col-"] + [class*="col-"] {
+    margin-bottom: 10px;
+}
+
+@media (min-width: 1200px) {
+    .form-stack.form-group [class*="col-lg-"] + [class*="col-lg-"] {
+        margin-bottom: 0;
+    }
+}
+@media (min-width: 992px) {
+    .form-stack.form-group [class*="col-md-"] + [class*="col-md-"] {
+        margin-bottom: 0;
+    }
+}

--- a/templates/base-barebones.jinja
+++ b/templates/base-barebones.jinja
@@ -5,8 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>
-        {%- block title %}{% endblock -%}
-        {%- if self.title() %} · {% endif -%}
+        {%- if title %}{{ title }} · {% endif -%}
         SPFs ❝SPBM❞
     </title>
     <link href="{{ static("css/bootstrap.min.css") }}" rel="stylesheet">

--- a/templates/base.jinja
+++ b/templates/base.jinja
@@ -5,8 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>
-        {%- block title %}{% endblock -%}
-        {%- if self.title() %} · {% endif -%}
+        {%- if title -%}
+            {{ title | striptags }}
+            {% if title_small -%}
+                - {{ title_small | striptags }}
+            {%- endif %}
+            ·
+        {% endif -%}
         SPFs ❝SPBM❞
     </title>
     <link href="{{ static("css/bootstrap.min.css") }}" rel="stylesheet">
@@ -78,8 +83,12 @@
     </div>
 </nav>
 <div class="container">
-    {% if self.title() -%}
-        <h1 class="page-header">{{ self.title() }}</h1>
+    {% if title -%}
+        <h1 class="page-header">{{ title }}
+            {%- if title_small %}
+                <small>{{ title_small | striptags }}</small>
+            {% endif -%}
+        </h1>
     {%- endif %}
     {% if messages -%}
         <ul class="messages list-unstyled" role="alert">

--- a/templates/base.jinja
+++ b/templates/base.jinja
@@ -84,11 +84,18 @@
 </nav>
 <div class="container">
     {% if title -%}
-        <h1 class="page-header">{{ title }}
-            {%- if title_small %}
-                <small>{{ title_small | striptags }}</small>
-            {% endif -%}
-        </h1>
+        <div class="page-header">
+            {% if self.toolbar() -%}
+                <div class="btn-group pull-right" role="group">
+                    {% block toolbar %}{% endblock %}
+                </div>
+            {%- endif %}
+            <h1>{{ title }}
+                {%- if title_small %}
+                    <small>{{ title_small | striptags }}</small>
+                {% endif -%}
+            </h1>
+        </div>
     {%- endif %}
     {% if messages -%}
         <ul class="messages list-unstyled" role="alert">

--- a/templates/events/add.jinja
+++ b/templates/events/add.jinja
@@ -1,8 +1,5 @@
 {% extends "events/form.jinja" %}
-
-{% block title -%}
-    {{ _('Add event') }}
-{%- endblock %}
+{% set title = _("Add event") %}
 
 {% block buttons %}
         <div class="col-sm-offset-2 col-sm-10">

--- a/templates/events/add.jinja
+++ b/templates/events/add.jinja
@@ -1,37 +1,10 @@
-{% extends "base.jinja" %}
+{% extends "events/form.jinja" %}
 
 {% block title -%}
     {{ _('Add event') }}
 {%- endblock %}
 
-{% block content %}
-<form class="form-horizontal" method="post" action="">
-    {% csrf_token %}
-    {% autoescape off %}
-
-    <h3>{{ _('Event details') }}</h3>
-
-    {# Include and enumerate through the main form #}
-    {% include 'form-loop.jinja' %}
-
-    <h3>{{ _('Shift workers') }}</h3>
-
-    {# Go through all of the inline forms that are #}
-    {% for inline in inlines %}
-        {# If the formset has errors, show these #}
-        {% if inline.non_form_errors() %}
-            {% for error in inline.non_form_errors() %}
-            <div class="alert alert-warning">{{ error }}</div>
-            {% endfor %}
-        {% endif %}
-        {% for form in inline %}
-            {% include 'form-loop-columns.jinja' %}
-        {% endfor %}
-        {{ inline.management_form }}
-    {% endfor %}
-
-    {# Add the submit and cancel buttons #}
-    <div class="form-group">
+{% block buttons %}
         <div class="col-sm-offset-2 col-sm-10">
             <button type="submit" class="btn btn-success">
                 {{ _('Create event') }}
@@ -40,7 +13,4 @@
                 {{ _('Cancel creating this event') }}
             </a>
         </div>
-    </div>
-    {% endautoescape %}
-    {% endblock %}
-</form>
+{% endblock buttons %}

--- a/templates/events/add.jinja
+++ b/templates/events/add.jinja
@@ -8,15 +8,15 @@
 <form class="form-horizontal" method="post" action="">
     {% csrf_token %}
     {% autoescape off %}
-    {% for form in event_formset %}
+{#    {% for form in event_formset %}#}
         {% include 'form-loop.jinja' %}
-    {% endfor %}
-    {{ event_formset.management_form }}
+{#    {% endfor %}#}
+{#    {{ event_formset.management_form }}#}
 
-    {% for form in shift_formset %}
-        {% include 'form-loop.jinja' %}
-    {% endfor %}
-    {{ shift_formset.management_form }}
+{#    {% for form in shift_formset %}#}
+{#        {% include 'form-loop.jinja' %}#}
+{#    {% endfor %}#}
+{#    {{ shift_formset.management_form }}#}
     {# <table>
         {{ event_formset }}
     </table>

--- a/templates/events/delete.jinja
+++ b/templates/events/delete.jinja
@@ -13,7 +13,7 @@
             <div class="panel-body">
                 <p>{{ _("Are you sure that you wish to delete the event %(event)s?", event=object) }}</p>
                 <div class="">
-                    <a href="{{ url('events') }}" class="btn btn-success">
+                    <a href="{{ url('event-view', object.id) }}" class="btn btn-success">
                         {{ _("Cancel deleting and take me back") }}
                     </a>
                     <input class="btn btn-danger" type="submit" value="{{ _("Delete the event") }}"/>

--- a/templates/events/delete.jinja
+++ b/templates/events/delete.jinja
@@ -1,0 +1,27 @@
+{% extends "base.jinja" %}
+
+{% block title %}
+    {{ _("Confirm deletion of event") }}
+{% endblock %}
+
+{% block content %}
+    <form action="" method="post">
+        {%- csrf_token %}
+        <div class="panel panel-danger">
+            <div class="panel-heading">
+                <h2 class="panel-title">
+                    {{ _("Confirm deletion") }}
+                </h2>
+            </div>
+            <div class="panel-body">
+                <p>{{ _("Are you sure that you wish to delete the event %(event)s?", event=object) }}</p>
+                <div class="">
+                    <a href="{{ url('events') }}" class="btn btn-success">
+                        {{ _("Cancel deleting and take me back") }}
+                    </a>
+                    <input class="btn btn-danger" type="submit" value="{{ _("Delete the event") }}"/>
+                </div>
+            </div>
+        </div>
+    </form>
+{% endblock %}

--- a/templates/events/delete.jinja
+++ b/templates/events/delete.jinja
@@ -1,8 +1,5 @@
 {% extends "base.jinja" %}
-
-{% block title %}
-    {{ _("Confirm deletion of event") }}
-{% endblock %}
+{% set title = _("Confirm deletion of event") %}
 
 {% block content %}
     <form action="" method="post">

--- a/templates/events/edit.jinja
+++ b/templates/events/edit.jinja
@@ -1,8 +1,5 @@
 {% extends "events/form.jinja" %}
-
-{% block title -%}
-    {{ _("Edit event") }}
-{%- endblock %}
+{% set title = _("Edit event") %}
 
 {% block buttons %}
         <div class="col-sm-offset-2 col-sm-10">

--- a/templates/events/edit.jinja
+++ b/templates/events/edit.jinja
@@ -1,29 +1,10 @@
-{% extends "base.jinja" %}
+{% extends "events/form.jinja" %}
 
 {% block title -%}
     {{ _("Edit event") }}
 {%- endblock %}
 
-{% block content %}
-<form class="form-horizontal" method="post" action="">
-    {% csrf_token %}
-    {% autoescape off %}
-
-    <h3>{{ _('Event details') }}</h3>
-
-    {# Include and enumerate through the main form #}
-    {% include 'form-loop.jinja' %}
-
-    {# Go through all of the inline forms that are #}
-    {% for inline in inlines %}
-        {% for form in inline %}
-            {% include 'form-loop.jinja' %}
-        {% endfor %}
-        {{ inline.management_form }}
-    {% endfor %}
-
-    {# Add the submit and cancel buttons #}
-    <div class="form-group">
+{% block buttons %}
         <div class="col-sm-offset-2 col-sm-10">
             <button type="submit" class="btn btn-success">
                 {{ _('Update event with changes') }}
@@ -32,7 +13,4 @@
                 {{ _('Cancel changes') }}
             </a>
         </div>
-    </div>
-    {% endautoescape %}
-    {% endblock %}
-</form>
+{% endblock buttons %}

--- a/templates/events/edit.jinja
+++ b/templates/events/edit.jinja
@@ -1,7 +1,7 @@
 {% extends "base.jinja" %}
 
 {% block title -%}
-    {{ _('Add event') }}
+    {{ _("Edit event") }}
 {%- endblock %}
 
 {% block content %}
@@ -14,18 +14,10 @@
     {# Include and enumerate through the main form #}
     {% include 'form-loop.jinja' %}
 
-    <h3>{{ _('Shift workers') }}</h3>
-
     {# Go through all of the inline forms that are #}
     {% for inline in inlines %}
-        {# If the formset has errors, show these #}
-        {% if inline.non_form_errors() %}
-            {% for error in inline.non_form_errors() %}
-            <div class="alert alert-warning">{{ error }}</div>
-            {% endfor %}
-        {% endif %}
         {% for form in inline %}
-            {% include 'form-loop-columns.jinja' %}
+            {% include 'form-loop.jinja' %}
         {% endfor %}
         {{ inline.management_form }}
     {% endfor %}
@@ -34,10 +26,10 @@
     <div class="form-group">
         <div class="col-sm-offset-2 col-sm-10">
             <button type="submit" class="btn btn-success">
-                {{ _('Create event') }}
+                {{ _('Update event with changes') }}
             </button>
-            <a href="{{ url("events") }}" title="{{ _('Cancel creating this event') }}" class="btn btn-warning">
-                {{ _('Cancel creating this event') }}
+            <a href="{{ url("events") }}" title="{{ _('Cancel changes') }}" class="btn btn-warning">
+                {{ _('Cancel changes') }}
             </a>
         </div>
     </div>

--- a/templates/events/form.jinja
+++ b/templates/events/form.jinja
@@ -1,0 +1,36 @@
+{% extends "base.jinja" %}
+
+{% block content %}
+<form class="form-horizontal" method="post" action="">
+    {% csrf_token %}
+    {% autoescape off %}
+
+    <h3>{{ _('Event details') }}</h3>
+
+    {# Include and enumerate through the main form #}
+    {% include 'form-loop.jinja' %}
+
+    <h3>{{ _('Shift workers') }}</h3>
+
+    {# Go through all of the inline forms that are #}
+    {% for inline in inlines %}
+        {# If the formset has errors, show these #}
+        {% if inline.non_form_errors() %}
+            {% for error in inline.non_form_errors() %}
+            <div class="alert alert-warning">{{ error }}</div>
+            {% endfor %}
+        {% endif %}
+        {% for form in inline %}
+            {% include 'form-loop-columns.jinja' %}
+        {% endfor %}
+        {{ inline.management_form }}
+    {% endfor %}
+
+    {# Add the submit and cancel buttons #}
+    <div class="form-group">
+        {% block buttons -%}
+        {%- endblock buttons %}
+    </div>
+    {% endautoescape %}
+</form>
+{% endblock %}

--- a/templates/events/index.jinja
+++ b/templates/events/index.jinja
@@ -4,43 +4,80 @@
     {{ _("Events") }}
 {%- endblock %}
 
-{% block content %}
-    <a class="btn btn-success btn-lg" href="add/">{{ _("Add new event") }}</a>
-    {% for proc in processed %}
-        <p style="font-size: 150%; padding-top: 10pt;">
-            <strong>
-                {% if proc['processed'] is none %}
-                    {{ _("Not processed yet") }}
-                {% else %}
-                    {{ _('Processed on %(date)s', date=proc['processed']) }}
-                {% endif %}
-            </strong>
-        </p>
-        {% for event in events[proc['processed']] %}
-            <div class="event" style="padding-top: 10px">
-                <table class="table table-striped">
-                    <thead>
-                    <tr>
-                        <th style="width: 20%;">{{ _("Event") }}</th>
-                        <th style="width: 20%;">{{ _("Name") }}</th>
-                        <th style="width: 10%">{{ _("Hourly") }}</th>
-                        <th style="width: 10%">{{ _("Hours") }}</th>
-                        <th style="width: 10%">{{ _("Sum") }}</th>
-                    </thead>
-                    <tbody>
-                    {% for shift in event.shifts.all() %}
-                        <tr>
-                            <td>{% if loop.first %}{{ event.date }}: {{ event.name }}{% endif %}</td>
-                            <td>{{ shift.worker.name }}</td>
-                            <td>{{ shift.wage | intcomma }}</td>
-                            <td>{{ shift.hours | intcomma }}</td>
-                            <td>{{ _('NOK %(cost)s', cost=shift.get_total() | intcomma) }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-                {{ _('Total') }}: {{ _('NOK %(cost)s', cost=event.get_cost() | intcomma) }}
-            </div>
-        {% endfor %}
-    {% endfor %}
+{% block content -%}
+    <a class="btn btn-success btn-lg {%- if not user.has_perm('society.add_event') %} disabled {%- endif %}"
+       href="{{ url('event-add') }}"><i class="glyphicon glyphicon-plus"></i> {{ _("Add new event") }}</a>
+    {%- for processed, events in events %}
+        <h2>
+            {%- if processed is none -%}
+                {{ _("Not processed yet") }}
+            {%- else -%}
+                {{ _('Processed on %(date)s', date=processed | localize) }}
+            {%- endif -%}
+        </h2>
+        <table class="table table-striped">
+            <thead>
+            <tr>
+                <th>{{ _("Date") }}</th>
+                <th>{{ _("Event") }}</th>
+                <th>{{ _("Total hours") }}</th>
+                <th>{{ _("Total cost") }}</th>
+                <th>{{ _("Shift details") }}</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            {%- for event in events %}
+                <tr>
+                    <td>{{ event.date | localize }}</td>
+                    <td>{{ event.name }}</td>
+                    <td>{{ _('%(hours)sh', hours=event.hours | intcomma) }}</td>
+                    <td>{{ _('NOK %(cost)s', cost=event.cost | intcomma) }}</td>
+                    <td>
+                        <div class="event" style="padding-top: 10px">
+                            <table class="table table-striped">
+                                <thead>
+                                <tr>
+                                    <th style="width: 20%;">{{ _("Name") }}</th>
+                                    <th style="width: 10%">{{ _("Hourly") }}</th>
+                                    <th style="width: 10%">{{ _("Hours") }}</th>
+                                    <th style="width: 10%">{{ _("Sum") }}</th>
+                                </thead>
+                                <tbody>
+                                {%- for shift in event.shifts.all() %}
+                                    <tr>
+                                        <td>{{ shift.worker.name }}</td>
+                                        <td>{{ shift.wage | intcomma }}</td>
+                                        <td>{{ shift.hours | intcomma }}</td>
+                                        <td>{{ _('NOK %(cost)s', cost=shift.get_total() | intcomma) }}</td>
+                                    </tr>
+                                {%- endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </td>
+                    <td>
+                        <div class="btn-group btn-group-sm">
+                            <a href="{{ url('event-view', event.id) }}"
+                               title="{{ _("View the details of the event") }}" class="btn btn-info">
+                                <i class="glyphicon glyphicon-eye-open"></i>
+                                <span class="sr-only">{{ _("View event") }}</span>
+                            </a>
+                            {% if user.has_perm('society.change_event') and event.processed is none -%}
+                                <a href="{{ url('event-edit', event.id) }}"
+                                   title="{{ _("Edit the event, such as date, workers, and more") }}"
+                                   class="btn btn-warning">
+                                    <i class="glyphicon glyphicon-pencil"></i>
+                                    <span class="sr-only">{{ _("Edit event") }}</span>
+                                </a>
+                            {%- endif %}
+                        </div>
+
+                    </td>
+                </tr>
+                </a>
+            {%- endfor %}
+            </tbody>
+        </table>
+    {%- endfor %}
 {% endblock %}

--- a/templates/events/index.jinja
+++ b/templates/events/index.jinja
@@ -23,12 +23,12 @@
         <table class="table table-striped">
             <thead>
             <tr>
-                <th>{{ _("Date") }}</th>
-                <th>{{ _("Event") }}</th>
-                <th>{{ _("Total hours") }}</th>
-                <th>{{ _("Total cost") }}</th>
-                <th>{{ _("Shift details") }}</th>
-                <th></th>
+                <th class="col-md-2">{{ _("Date") }}</th>
+                <th class="col-md-3">{{ _("Event") }}</th>
+                <th class="col-md-1">{{ _("Total hours") }}</th>
+                <th class="col-md-2">{{ _("Total cost") }}</th>
+                <th class="col-md-2 col-lg-3">{{ _("Workers") }}</th>
+                <th class="col-sm-2 col-md-1 col-lg-1"></th>
             </tr>
             </thead>
             <tbody>
@@ -39,29 +39,13 @@
                     <td>{{ _('%(hours)sh', hours=event.hours | intcomma) }}</td>
                     <td>{{ _('NOK %(cost)s', cost=event.cost | intcomma) }}</td>
                     <td>
-                        <div class="event" style="padding-top: 10px">
-                            <table class="table table-striped">
-                                <thead>
-                                <tr>
-                                    <th style="width: 20%;">{{ _("Name") }}</th>
-                                    <th style="width: 10%">{{ _("Hourly") }}</th>
-                                    <th style="width: 10%">{{ _("Hours") }}</th>
-                                    <th style="width: 10%">{{ _("Sum") }}</th>
-                                </thead>
-                                <tbody>
-                                {%- for shift in event.shifts.all() %}
-                                    <tr>
-                                        <td>{{ shift.worker.name }}</td>
-                                        <td>{{ shift.wage | intcomma }}</td>
-                                        <td>{{ shift.hours | intcomma }}</td>
-                                        <td>{{ _('NOK %(cost)s', cost=shift.get_total() | intcomma) }}</td>
-                                    </tr>
-                                {%- endfor %}
-                                </tbody>
-                            </table>
-                        </div>
+                            {# {{ table_of_shifts(event.shifts.all()) }} #}
+                            {%- for shift in event.shifts.all() -%}
+                                {{ shift.worker.name }}
+                                {%- if not loop.last %}, {% endif -%}
+                            {%- endfor %}
                     </td>
-                    <td>
+                    <td class="col-md-1">
                         <div class="btn-group btn-group-sm">
                             <a href="{{ url('event-view', event.id) }}"
                                title="{{ _("View the details of the event") }}" class="btn btn-info">
@@ -77,7 +61,6 @@
                                 </a>
                             {%- endif %}
                         </div>
-
                     </td>
                 </tr>
                 </a>

--- a/templates/events/index.jinja
+++ b/templates/events/index.jinja
@@ -1,8 +1,5 @@
 {% extends "base.jinja" %}
-
-{% block title -%}
-    {{ _("Events") }}
-{%- endblock %}
+{% set title = _("Events") %}
 
 {% block content -%}
     <a class="btn btn-success btn-lg {%- if not user.has_perm('society.add_event') %} disabled {%- endif %}"

--- a/templates/events/index.jinja
+++ b/templates/events/index.jinja
@@ -1,9 +1,17 @@
 {% extends "base.jinja" %}
 {% set title = _("Events") %}
 
+{% from 'events/utils.jinja' import table_of_shifts %}
+
+{% block toolbar %}
+    <a class="btn btn-success {%- if not user.has_perm('society.add_event') %} disabled {%- endif %}"
+       href="{{ url('event-add') }}">
+        <span class="glyphicon glyphicon-asterisk"></span> {{ _("Add new event") }}
+    </a>
+{% endblock %}
+
 {% block content -%}
-    <a class="btn btn-success btn-lg {%- if not user.has_perm('society.add_event') %} disabled {%- endif %}"
-       href="{{ url('event-add') }}"><i class="glyphicon glyphicon-plus"></i> {{ _("Add new event") }}</a>
+
     {%- for processed, events in events %}
         <h2>
             {%- if processed is none -%}

--- a/templates/events/utils.jinja
+++ b/templates/events/utils.jinja
@@ -1,0 +1,35 @@
+{% macro table_of_shifts(shifts, classes='table-striped', payroll=False) %}
+    <table class="table {{ classes }}">
+        <thead>
+        <tr>
+            <th class="col-md-4">{{ _("Name") }}</th>
+            <th class="col-md-2 text-right">{{ _("Hourly") }}</th>
+            <th class="col-md-2 text-right">{{ _("Hours") }}</th>
+            <th class="col-md-2 text-right">{{ _("Sum") }}</th>
+            {% if payroll -%}<th class="text-center col-md-2">{{ _("Payrolled") }}</th>{%- endif %}
+        </thead>
+        <tbody>
+        {%- for shift in shifts %}
+            <tr>
+                <td>{{ shift.worker.name }}</td>
+                <td class="text-right">{{ _('NOK %(cost)s', cost=shift.wage | intcomma) }}</td>
+                <td class="text-right">{{ _('%(hours)sh', hours=shift.hours | intcomma) }}</td>
+                <td class="text-right">{{ _('NOK %(cost)s', cost=shift.get_total() | intcomma) }}</td>
+                {% if payroll -%}
+                    <td class="text-center">
+                        {%- if shift.norlonn_report -%}
+                            <i title="{{ shift.norlonn_report | localize }}"
+                               class="glyphicon glyphicon-ok-circle text-success"></i>
+                            <span class="sr-only">{{ shift.norlonn_report }}</span>
+                        {%- else -%}
+                            <i title="{{ _("Not payrolled") }}"
+                               class="glyphicon glyphicon-exclamation-sign text-warning"></i>
+                            <span class="sr-only">{{ _("Not payrolled") }}</span>
+                        {%- endif -%}
+                    </td>
+                {%- endif %}
+            </tr>
+        {%- endfor %}
+        </tbody>
+    </table>
+{% endmacro %}

--- a/templates/events/view.jinja
+++ b/templates/events/view.jinja
@@ -1,0 +1,12 @@
+{% extends "base.jinja" %}
+{% set title = _("View event") %}
+{% set title_small = _("Viewing ""%(name)s"" (#%(id)i)", name=event.name, id=event.id) %}
+
+{% block content %}
+
+    {% if event.processed is none %}
+        <a href="{{ url('event-delete', object.id) }}" class="pull-right btn btn-small btn-danger">
+            {{ _("Delete...") }}
+        </a>
+    {% endif %}
+{% endblock %}

--- a/templates/events/view.jinja
+++ b/templates/events/view.jinja
@@ -1,5 +1,6 @@
 {% extends "base.jinja" %}
 {% set title = _("View event") %}
+{# Translators: small title for viewing an event #}
 {% set title_small = _("Viewing ""%(name)s"" (#%(id)i)", name=event.name, id=event.id) %}
 
 {% from 'events/utils.jinja' import table_of_shifts %}
@@ -24,5 +25,42 @@
 {% endblock %}
 
 {% block content %}
+    <div class="row">
+        <div class="col-md-7">
+            <h2>{{ _("Event details") }}</h2>
+            <table class="table table-bordered table-striped table-responsive">
+                <tbody>
+                {{ field(_("Name"), object.name) }}
+                {{ field(_("Society"), object.society.name) }}
+                {{ field(_("Date"), object.date | localize) }}
+                {{ field(_("Total hours"),  _('%(hours)sh', hours = object.hours | intcomma )) }}
+                {{ field(_("Total cost"), _('NOK %(cost)s', cost = object.cost | intcomma)) }}
+                </tbody>
+            </table>
+        </div>
+        <div class="col-md-5">
+            <h2>{{ _("Invoicing and wage details") }}</h2>
+            {% if event.processed is none %}
+                <div class="alert-info alert">
+                    <p>{% trans invoices = url('invoices') -%}
+                        This event has yet to be invoiced to a society. Please see
+                        <a href="{{ invoices }}" class="alert-link">the invoice section</a> to close the
+                        current invoice period.
+                    {% endtrans %}</p>
+                </div>
+            {% elif event.processed %}
+                <div class="alert alert-success">
+                    <p>{% trans society = event.society.name, payroll = url('wages') -%}
+                        This event has been invoiced to {{ society }}, and the wages will be paid to workers as soon as
+                        a <a class="alert-link" href="{{ payroll }}">payroll report has been created</a> for all valid
+                        workers.
+                    {% endtrans %}</p>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+
+    <h2>{{ _("Shift details") }}</h2>
+    {{ table_of_shifts(object.shifts.all(), payroll=True) }}
 
 {% endblock %}

--- a/templates/events/view.jinja
+++ b/templates/events/view.jinja
@@ -2,11 +2,27 @@
 {% set title = _("View event") %}
 {% set title_small = _("Viewing ""%(name)s"" (#%(id)i)", name=event.name, id=event.id) %}
 
+{% from 'events/utils.jinja' import table_of_shifts %}
+
+{% macro field(title, value) -%}
+    <tr>
+        <th class="col-sm-4">{{ title }}</th>
+        <td>{{ value }}</td>
+    </tr>
+{%- endmacro %}
+
+
+{% block toolbar %}
+    {%- if event.processed is none %}
+    <a href="{{ url('event-edit', object.id) }}" class="btn btn-small btn-warning">
+        {{ _("Edit event") }}
+    </a>
+    <a href="{{ url('event-delete', object.id) }}" class="btn btn-small btn-danger">
+        {{ _("Delete event") }}
+    </a>
+    {% endif -%}
+{% endblock %}
+
 {% block content %}
 
-    {% if event.processed is none %}
-        <a href="{{ url('event-delete', object.id) }}" class="pull-right btn btn-small btn-danger">
-            {{ _("Delete...") }}
-        </a>
-    {% endif %}
 {% endblock %}

--- a/templates/form-loop-columns.jinja
+++ b/templates/form-loop-columns.jinja
@@ -1,0 +1,47 @@
+{% macro fielder(field, sm=10, label_sm=2, lg=10, label_lg=2, group=False) %}
+    {% if not field.errors and not field.is_hidden %}
+        <div>
+            <label class="col-sm-{{ label_sm }} col-lg-{{ label_lg }} control-label" for="{{ field.auto_id }}">{{ field.label }}</label>
+            <div class="col-sm-{{ sm }} col-lg-{{ lg }}">
+                {{ field | attr("class:form-control") }}
+                {% if field.help_text %}
+                    <p class="help-block">
+                        <small>{{ field.help_text | safe }}</small>
+                    </p>
+                {% endif %}
+            </div>
+        </div>
+    {% elif field.errors %}
+        <div class="has-error">
+            <label class="col-sm-{{ label_sm }} col-lg-{{ label_lg }} control-label" for="{{ field.auto_id }}">{{ field.label }}</label>
+            <div class="col-sm-{{ sm }} col-lg-{{ lg }}">
+                {{ field | attr("class:form-control") }}
+                <span class="help-block">
+                    {% for error in field.errors %}{{ error }}{% endfor %}
+                </span>
+            </div>
+        </div>
+    {% elif field.is_hidden %}
+        {{ field }}
+    {% endif %}
+{% endmacro %}
+
+
+{% if form.non_field_errors() %}
+    {% for error in form.non_field_errors() %}
+        <div class="alert alert-danger">{{ error }}</div>
+    {% endfor %}
+    <div class="form-group form-stack has-error">
+{% else %}
+    <div class="form-group form-stack">
+{% endif %}
+    {% for field in form %}
+        {% if field.name == "worker" %}
+            {{ fielder(field, lg=4) }}
+        {% elif field.name == "hours" or field.name == "wage" %}
+            {{ fielder(field, label_lg=1, lg=2) }}
+        {% else %}
+            {{ fielder(field) }}
+        {% endif %}
+    {% endfor %}
+</div>

--- a/templates/form-loop.jinja
+++ b/templates/form-loop.jinja
@@ -1,15 +1,13 @@
+{% if form.non_field_errors() %}
+    {% for error in form.non_field_errors() %}
+        <div class="alert alert-danger">{{ error }}</div>
+    {% endfor %}
+    <div class="has-error">
+{% else %}
+    <div>
+{% endif %}
 {% for field in form %}
-    {% if field.errors %}
-        <div class="form-group has-error">
-            <label class="col-sm-2 control-label" for="id_{{ field.name }}">{{ field.label }}</label>
-            <div class="col-sm-10">
-                {{ field | attr("class:form-control") }}
-                <span class="help-block">
-                    {% for error in field.errors %}{{ error }}{% endfor %}
-                </span>
-            </div>
-        </div>
-    {% else %}
+    {% if not field.errors and not field.is_hidden %}
         <div class="form-group">
             <label class="col-sm-2 control-label" for="id_{{ field.name }}">{{ field.label }}</label>
             <div class="col-sm-10">
@@ -21,5 +19,18 @@
                 {% endif %}
             </div>
         </div>
+    {% elif field.errors %}
+        <div class="form-group has-error">
+            <label class="col-sm-2 control-label" for="id_{{ field.name }}">{{ field.label }}</label>
+            <div class="col-sm-10">
+                {{ field | attr("class:form-control") }}
+                <span class="help-block">
+                    {% for error in field.errors %}{{ error }}{% endfor %}
+                </span>
+            </div>
+        </div>
+    {% elif field.is_hidden %}
+        {{ field }}
     {% endif %}
 {% endfor %}
+</div>

--- a/templates/index.jinja
+++ b/templates/index.jinja
@@ -1,8 +1,5 @@
 {% extends "base.jinja" %}
-
-{% block title -%}
-    {{ _('Society overview') }}
-{%- endblock %}
+{% set title = _('Society overview') %}
 
 {% block content %}
     <p>{{ _("You're logged into an account associated with:") }} {{ society.name }} ({{ society.shortname }})</p>

--- a/templates/invoices/index.jinja
+++ b/templates/invoices/index.jinja
@@ -1,7 +1,5 @@
 {% extends "base.jinja" %}
-{% block title -%}
-    {{ _("Invoice Management") }}
-{%- endblock %}
+{% set title = _("Invoice Management") %}
 
 {% block content %}
 <section class="row">

--- a/templates/invoices/view.jinja
+++ b/templates/invoices/view.jinja
@@ -1,9 +1,8 @@
 {% extends "base.jinja" %}
-
-{% block title -%}
-    {{ _("Invoice #%(id)s: %(date)s %(society)s", id=invoice.invoice_number,
-    date=invoice.period, society=invoice.society) }}
-{%- endblock %}
+{% set title = _("Invoice #%(id)s: %(date)s %(society)s",
+    id=invoice.invoice_number,
+    date=invoice.period,
+    society=invoice.society) %}
 
 {% block content %}
     <article>

--- a/templates/norlonn/index.jinja
+++ b/templates/norlonn/index.jinja
@@ -1,9 +1,8 @@
 {% extends "base.jinja" %}
-
-{% block title %}
+{% set title -%}
     {# Translators: Title for reports page. #}
     {{ _("Wage Reports") }}
-{% endblock %}
+{%- endset %}
 
 {% block content %}
     <p>

--- a/templates/workers/edit.jinja
+++ b/templates/workers/edit.jinja
@@ -1,7 +1,6 @@
 {% extends "base.jinja" %}
-{% block title -%}
-    {{ _('Edit worker') }}
-{%- endblock %}
+{% set title = _('Edit worker') %}
+
 {% block content %}
     <style>
         .new {

--- a/templates/workers/index.jinja
+++ b/templates/workers/index.jinja
@@ -1,8 +1,5 @@
 {% extends "base.jinja" %}
-
-{% block title -%}
-    {{ _("Workers") }}
-{%- endblock %}
+{% set title = _("Workers") %}
 
 {% block content %}
     <h2>{{ _('Add new worker') }}</h2>

--- a/wercker.yml
+++ b/wercker.yml
@@ -60,10 +60,11 @@ build:
 
     # Installing the CI requirements, incl. coveralls and coverage
     - script:
-        name: pip install coverage outside of requirements.txt w/wheel
+        name: install coverage/coveralls outside of requirements.txt w/wheel
         code: |
-          pip wheel coverage
-          pip install coverage
+          apk add git
+          pip wheel coverage coveralls
+          pip install coverage coveralls
 
     # A step that executes `pip install` command.
     - pip-install:
@@ -89,16 +90,10 @@ build:
         code: |
           python ./manage.py compilemessages
 
-  after-steps:
-    # Installing the CI requirements, incl. coveralls and coverage
+    # We're done with our building now: seeing as the build has successfully been completed,
+    # we now report the coverage for our tests.
+
     - script:
-        name: installing software requirements for coveralls
-        code: |
-          export PIP_CACHE_DIR=$WERCKER_CACHE_DIR/pip-download-cache
-          export PIP_FIND_LINKS=$WERCKER_CACHE_DIR/pip-wheels
-          apk add git
-          pip install coveralls
-    - script: 
         name: reporting to coveralls
         code: |
           info "Setting up environment variables for correct coveralls reporting"
@@ -107,7 +102,7 @@ build:
           export CI_BUILD_URL=$WERCKER_BUILD_URL
           info "Report to coveralls"
           COVERALLS_REPO_TOKEN=$COVERALLS_TOKEN coveralls
-        
+
 ################################################################################
 # Deployment pipeline
 # - Takes care of putting the bits and bytes in the right place.


### PR DESCRIPTION
## Background

Editing events is very bare-bones at the moment, and lacks a lot of features that would make it generally more usable for... anything.

- A created event cannot be edited (without having admin access, of some sort)
  - Incorrect details cannot be changed
  - This applies to invoiced events too, which cannot even be edited from the admin panel 😢 
- Poor user experience when adding events
- Cannot add more than seven shifts, but usually that's not even necessary
- No details regarding what invoice an event is part of, or which wage report it was part of

In terms of the code, it can now be swapped over to use parts of CBV, although with inlines and whatnot there'll always be some mess.

## Rough plan

- [X] Create a minimum viable CBV-version of the events adding
  - [x] Make it fancier
  - [x] ... but also make it simpler
- [x] Create a minimum viable CBV-version of updating events
  - [x] Decide on how to deal with events that have been invoiced 😨 
  - [x] Make events reasonably updateable before invoicing
  - [ ] Allow events to be "unready" to be invoiced, or just "not ready" or "not approved"
  - [x] Add another admin model for events without limitations, separate from current
- [x] Separate the events addition template into adding and editing
- [x] Change up the events overview page
  - [ ] Pagination? 📄 
  - [x] Linking to the events edit-page 💾 
  - [ ] A calendar?  📆 
- [x] Add tests for the fun stuff